### PR TITLE
[Film/#30] NavigationBar(header와 footer)컴포넌트 생성

### DIFF
--- a/src/components/atoms/Navigation/FooterNavigation/index.tsx
+++ b/src/components/atoms/Navigation/FooterNavigation/index.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+import { Container, Wrapper } from './style';
+
+export interface Props {
+  contents?: ReactNode;
+  bgColor?: string;
+}
+const FooterNavigation = ({ contents, bgColor }: Props) => {
+  return (
+    <Wrapper bgColor={bgColor}>
+      <Container>{contents}</Container>
+    </Wrapper>
+  );
+};
+export default FooterNavigation;

--- a/src/components/atoms/Navigation/FooterNavigation/style.ts
+++ b/src/components/atoms/Navigation/FooterNavigation/style.ts
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+
+const Wrapper = styled.nav<{ bgColor?: string }>`
+  position: sticky;
+  width: 100%;
+  height: 52px;
+  bottom: 0;
+  left: 0;
+  background-color: ${({ bgColor }) => (bgColor ? bgColor : 'white')};
+`;
+const Container = styled.ul`
+  height: inherit;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+`;
+
+export { Wrapper, Container };

--- a/src/components/atoms/Navigation/HeaderNavigation/index.tsx
+++ b/src/components/atoms/Navigation/HeaderNavigation/index.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+import { LeftSide, MiddleSide, RightSide, Wrapper, Side } from './style';
+
+export interface Props {
+  leftSide?: ReactNode;
+  middleSide?: ReactNode;
+  rightSide?: ReactNode;
+  gap?: number;
+}
+const HeaderNavigation = ({ leftSide, rightSide, middleSide, gap }: Props) => {
+  return (
+    <Wrapper>
+      {middleSide && <MiddleSide gap={gap}>{middleSide}</MiddleSide>}
+      {(leftSide || rightSide) && (
+        <Side>
+          {leftSide && <LeftSide gap={gap}>{leftSide}</LeftSide>}
+          {rightSide && <RightSide gap={gap}>{rightSide}</RightSide>}
+        </Side>
+      )}
+    </Wrapper>
+  );
+};
+export default HeaderNavigation;

--- a/src/components/atoms/Navigation/HeaderNavigation/index.tsx
+++ b/src/components/atoms/Navigation/HeaderNavigation/index.tsx
@@ -6,10 +6,11 @@ export interface Props {
   middleSide?: ReactNode;
   rightSide?: ReactNode;
   gap?: number;
+  bgColor?: string;
 }
-const HeaderNavigation = ({ leftSide, rightSide, middleSide, gap }: Props) => {
+const HeaderNavigation = ({ leftSide, rightSide, middleSide, gap, bgColor }: Props) => {
   return (
-    <Wrapper>
+    <Wrapper bgColor={bgColor}>
       {middleSide && <MiddleSide gap={gap}>{middleSide}</MiddleSide>}
       {(leftSide || rightSide) && (
         <Side>

--- a/src/components/atoms/Navigation/HeaderNavigation/style.ts
+++ b/src/components/atoms/Navigation/HeaderNavigation/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
-const Wrapper = styled.ul`
-  position: fixed;
+const Wrapper = styled.nav<{ bgColor?: string }>`
+  position: sticky;
   left: 0;
   top: 0;
   width: 100%;
@@ -10,9 +10,9 @@ const Wrapper = styled.ul`
   justify-content: center;
   align-items: center;
   box-shadow: ${({ theme }) => theme.colors.shadow};
-  background: white;
+  background-color: ${({ bgColor }) => (bgColor ? bgColor : 'white')};
 `;
-const MiddleSide = styled.div<{ gap?: number }>`
+const MiddleSide = styled.ul<{ gap?: number }>`
   position: relative;
   margin: 0 auto;
   display: flex;
@@ -28,7 +28,7 @@ const Side = styled.div`
   justify-content: center;
   align-items: center;
 `;
-const LeftSide = styled.div<{ gap?: number }>`
+const LeftSide = styled.ul<{ gap?: number }>`
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/atoms/Navigation/HeaderNavigation/style.ts
+++ b/src/components/atoms/Navigation/HeaderNavigation/style.ts
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+
+const Wrapper = styled.ul`
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 52px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow: ${({ theme }) => theme.colors.shadow};
+  background: white;
+`;
+const MiddleSide = styled.div<{ gap?: number }>`
+  position: relative;
+  margin: 0 auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: ${({ gap }) => `${gap ? gap : 0}px`};
+`;
+const Side = styled.div`
+  position: absolute;
+  width: 100%;
+  height: inherit;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+const LeftSide = styled.div<{ gap?: number }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0 auto 0 28px;
+  gap: ${({ gap }) => `${gap ? gap : 0}px`};
+`;
+const RightSide = styled(LeftSide)`
+  margin: 0 28px 0 auto;
+`;
+
+export { Wrapper, LeftSide, RightSide, MiddleSide, Side };

--- a/src/components/atoms/Navigation/index.tsx
+++ b/src/components/atoms/Navigation/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import HeaderNavigation from './HeaderNavigation';
+import FooterNavigation from './FooterNavigation';
+import { Props as HeaderNavProps } from './HeaderNavigation';
+
+interface Props extends HeaderNavProps {
+  navType: 'header' | 'footer';
+}
+const Navigation = ({ navType, leftSide, rightSide, middleSide }: Props) => {
+  const isHeader = navType == 'header';
+  return (
+    <>
+      {isHeader && (
+        <HeaderNavigation
+          leftSide={leftSide}
+          middleSide={middleSide}
+          rightSide={rightSide}
+          gap={20}
+        />
+      )}
+      {!isHeader && <FooterNavigation />}
+    </>
+  );
+};
+export default Navigation;

--- a/src/components/atoms/Navigation/index.tsx
+++ b/src/components/atoms/Navigation/index.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import HeaderNavigation from './HeaderNavigation';
 import FooterNavigation from './FooterNavigation';
 import { Props as HeaderNavProps } from './HeaderNavigation';
-
-interface Props extends HeaderNavProps {
+import { Props as FooterNavProps } from './FooterNavigation';
+interface Props extends HeaderNavProps, FooterNavProps {
   navType: 'header' | 'footer';
 }
-const Navigation = ({ navType, leftSide, rightSide, middleSide }: Props) => {
+const Navigation = ({ navType, leftSide, rightSide, middleSide, contents, bgColor }: Props) => {
   const isHeader = navType == 'header';
   return (
     <>
@@ -18,7 +18,7 @@ const Navigation = ({ navType, leftSide, rightSide, middleSide }: Props) => {
           gap={20}
         />
       )}
-      {!isHeader && <FooterNavigation />}
+      {!isHeader && <FooterNavigation contents={contents} bgColor={bgColor} />}
     </>
   );
 };

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -2,3 +2,4 @@ export { default as Text } from './Text';
 export { default as Button } from './Button';
 export { default as Upload } from './Upload';
 export { default as Modal } from './Modal';
+export { default as Navigation } from '../atoms/Navigation';

--- a/src/stories/components/FooterNavigation.stories.tsx
+++ b/src/stories/components/FooterNavigation.stories.tsx
@@ -16,9 +16,11 @@ export const Default = () => {
   );
 
   return (
-    <Wrapper>
+    <>
+      <Wrapper></Wrapper>
+      안녕하세요
       <Navigation navType="footer" contents={contents} />
-    </Wrapper>
+    </>
   );
 };
 

--- a/src/stories/components/FooterNavigation.stories.tsx
+++ b/src/stories/components/FooterNavigation.stories.tsx
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled';
+import React from 'react';
+import { Navigation } from '../../components/atoms';
+export default {
+  title: 'Example/FooterNavigation',
+  component: Navigation,
+};
+
+export const Default = () => {
+  const contents = (
+    <>
+      <li>
+        <a href="">홈으로</a>
+      </li>
+    </>
+  );
+
+  return (
+    <Wrapper>
+      <Navigation navType="footer" contents={contents} />
+    </Wrapper>
+  );
+};
+
+export const Test1 = () => {
+  const contents = (
+    <>
+      <li>
+        <a href="">홈으로</a>
+      </li>
+      <li>
+        <a href="">카메라</a>
+      </li>
+      <li>
+        <a href="">마이페이지</a>
+      </li>
+    </>
+  );
+
+  return (
+    <>
+      <Wrapper></Wrapper>
+      안녕하세요
+      <Navigation navType="footer" contents={contents} />
+    </>
+  );
+};
+const Wrapper = styled.div`
+  width: 500px;
+  height: 1000px;
+  background-color: red;
+`;

--- a/src/stories/components/HeaderNavigation.stories.tsx
+++ b/src/stories/components/HeaderNavigation.stories.tsx
@@ -4,7 +4,7 @@ import { Navigation } from '../../components/atoms';
 import { IoChevronBackOutline } from 'react-icons/io5';
 import { BsTrashFill } from 'react-icons/bs';
 export default {
-  title: 'Example/Navigation',
+  title: 'Example/HeaderNavigation',
   component: Navigation,
 };
 

--- a/src/stories/components/Navigation.stories.tsx
+++ b/src/stories/components/Navigation.stories.tsx
@@ -1,0 +1,173 @@
+import styled from '@emotion/styled';
+import React from 'react';
+import { Navigation } from '../../components/atoms';
+import { IoChevronBackOutline } from 'react-icons/io5';
+import { BsTrashFill } from 'react-icons/bs';
+export default {
+  title: 'Example/Navigation',
+  component: Navigation,
+};
+
+export const Default = () => {
+  const leftSide = (
+    <>
+      <li>
+        <a href="">
+          <IoChevronBackOutline />
+        </a>
+      </li>
+    </>
+  );
+  const rightSide = (
+    <>
+      <li>
+        <a href="">
+          <BsTrashFill />
+        </a>
+      </li>
+    </>
+  );
+  return (
+    <Wrapper>
+      <Navigation navType="header" leftSide={leftSide} rightSide={rightSide} />
+    </Wrapper>
+  );
+};
+
+export const Test1 = () => {
+  const leftSide = (
+    <>
+      <li>
+        <a href="">
+          <IoChevronBackOutline />
+        </a>
+      </li>
+      <li>
+        <a href="">
+          <IoChevronBackOutline />
+        </a>
+      </li>
+    </>
+  );
+  const rightSide = (
+    <>
+      <li>
+        <a href="">
+          <BsTrashFill />
+        </a>
+      </li>
+    </>
+  );
+  return (
+    <Wrapper>
+      <Navigation navType="header" leftSide={leftSide} rightSide={rightSide} gap={20} />
+    </Wrapper>
+  );
+};
+
+export const Test2 = () => {
+  const leftSide = (
+    <>
+      <li>
+        <a href="">
+          <IoChevronBackOutline />
+        </a>
+      </li>
+      <li>
+        <a href="">
+          <IoChevronBackOutline />
+        </a>
+      </li>
+    </>
+  );
+  const middleSide = (
+    <>
+      <li>
+        <a href="">페이지 위치</a>
+      </li>
+    </>
+  );
+  return (
+    <Wrapper>
+      <Navigation navType="header" leftSide={leftSide} middleSide={middleSide} gap={20} />
+    </Wrapper>
+  );
+};
+
+export const Test3 = () => {
+  const rightSide = (
+    <>
+      <li>
+        <a href="">
+          <IoChevronBackOutline />
+        </a>
+      </li>
+      <li>
+        <a href="">
+          <IoChevronBackOutline />
+        </a>
+      </li>
+    </>
+  );
+  const middleSide = (
+    <>
+      <li>
+        <a href="">페이지 위치</a>
+      </li>
+    </>
+  );
+  return (
+    <Wrapper>
+      <Navigation navType="header" rightSide={rightSide} middleSide={middleSide} gap={20} />
+    </Wrapper>
+  );
+};
+
+export const Test4 = () => {
+  const rightSide = (
+    <>
+      <li>
+        <a href="">
+          <IoChevronBackOutline />
+        </a>
+      </li>
+      <li>
+        <a href="">
+          <IoChevronBackOutline />
+        </a>
+      </li>
+    </>
+  );
+  const leftSide = (
+    <>
+      <li>
+        <a href="">
+          <IoChevronBackOutline />
+        </a>
+      </li>
+    </>
+  );
+  const middleSide = (
+    <>
+      <li>
+        <a href="">페이지 위치</a>
+      </li>
+    </>
+  );
+  return (
+    <Wrapper>
+      <Navigation
+        navType="header"
+        leftSide={leftSide}
+        rightSide={rightSide}
+        middleSide={middleSide}
+        gap={20}
+      />
+    </Wrapper>
+  );
+};
+const Wrapper = styled.div`
+  width: 500px;
+  height: 500px;
+  background-color: red;
+`;


### PR DESCRIPTION
## 📝 작업한 내용
 헤더바와 푸터바 생성

## 📌 리뷰 시 참고 사항
- 시맨틱하게 태그가 만들어졌는지 확인부탁드립니다!

## 📷 화면 사진
|헤더|헤더|푸터|푸터|
|---|---|---|---|
|<img src="https://user-images.githubusercontent.com/70435257/145171563-d371fadc-a367-416a-924d-fb7f212c765c.png" />|<img src="https://user-images.githubusercontent.com/70435257/145171580-762e9e9e-0d52-47fb-a39e-c636b406bd7e.png" />|<img src="https://user-images.githubusercontent.com/70435257/145171628-b326a6fa-f356-41e8-978c-46b4950c3475.png"/>|<img src="https://user-images.githubusercontent.com/70435257/145172169-1d5efcf2-751f-4c4f-8bca-c51e1a698868.png" />|

## 🧪 사용방법
- navType을 통해서 header와 footer를 선택할 수 있습니다.
- `nav태그와 ul태그`로 구성이 되어있기 때문에 컴포넌트를 넣을 떄 되도록 `li태그와 a 태그`를 통해 시맨틱하게 유지합니다.
- header의 경우
    - leftSide, RightSide, middleSide에 원하는 컴포넌트들을 넣어줄 수 있습니다.
    - gap은 leftSide안에 있는 컴포넌트들의 간격을 의미합니다.
    - gap을 설정한다면 모든 Side의 gap이 동일하게 설정됩니다.
    - bgColor를 통해 색상을 지정해 줄 수 있습니다.
- footer의 경우
    - contents를 통해 안의 컴포넌트를 설정할 수 있습니다.
    - `justify-content: space-around` 속성을 통해 균일하게 푸터가 여백을 가집니다.

closes #30