### PR TITLE
[film/#36] CreatePostPage 필름 내용 입력 페이지 작성

### DIFF
--- a/src/components/atoms/Upload/types.ts
+++ b/src/components/atoms/Upload/types.ts
@@ -1,7 +1,7 @@
-import { ChangeEvent, ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 export interface UploadProps {
-  onChange(e: ChangeEvent<HTMLInputElement>): void;
+  onChange(file: File): void;
   children?: ReactNode;
   name?: string;
   accept?: string;

--- a/src/pages/CreatePostPage/FirstStep.tsx
+++ b/src/pages/CreatePostPage/FirstStep.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { Text } from '../../components/atoms';
+import { NextStepButton, MapHeaderText } from './style';
+import Map from './Map';
+import { Location } from './types';
+
+interface Props {
+  goNextStep(): void;
+  location: Location | null;
+  handleLocation(data: Location): void;
+}
+
+const FirstStep = ({ goNextStep, location, handleLocation }: Props) => {
+  const [userLocation, setUserLocation] = useState({ latitude: 37, longitude: 127 });
+  const [marker, setMarker] = useState({ latitude: 37, longitude: 126 });
+
+  const getGeoLocation = () => {
+    if (!navigator.geolocation) {
+      console.warn('GPS를 지원하지 않습니다.');
+      return;
+    }
+    navigator.geolocation.getCurrentPosition((position) => {
+      setUserLocation({
+        latitude: position.coords.latitude,
+        longitude: position.coords.longitude,
+      });
+    });
+  };
+
+  useEffect(() => {
+    if (!location) {
+      getGeoLocation();
+      return;
+    }
+    setUserLocation({
+      latitude: location.latitude,
+      longitude: location.longitude,
+    });
+  }, []);
+
+  const handleMarker = (data: Location) => {
+    setMarker(data);
+  };
+
+  const saveLocation = () => {
+    handleLocation(marker);
+    goNextStep();
+  };
+
+  return (
+    <>
+      <MapHeaderText textType="Heading3">
+        필름을 맡길
+        <br />
+        위치로 마커를 옮겨주세요
+      </MapHeaderText>
+      <Map
+        latitude={userLocation.latitude}
+        longitude={userLocation.longitude}
+        marker={marker}
+        onChangeMarker={handleMarker}
+      />
+      <NextStepButton buttonType="PrimaryBtn" onClick={saveLocation}>
+        <Text textType="Paragraph1">여기에 만들래요</Text>
+      </NextStepButton>
+    </>
+  );
+};
+
+export default FirstStep;

--- a/src/pages/CreatePostPage/Map.tsx
+++ b/src/pages/CreatePostPage/Map.tsx
@@ -1,25 +1,21 @@
-import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import MapGl, { Marker } from 'react-map-gl';
 import Pin from './Pin';
+import { Location } from './types';
 
 interface Props {
   latitude: number;
   longitude: number;
-  onChangeLocation: Dispatch<
-    SetStateAction<{
-      latitude: number;
-      longitude: number;
-    }>
-  >;
+  marker: Location;
+  onChangeMarker(data: Location): void;
 }
 
-const Map = ({ latitude, longitude, onChangeLocation }: Props) => {
+const Map = ({ latitude, longitude, marker, onChangeMarker }: Props) => {
   const [viewport, setViewport] = useState({
     latitude: 37,
     longitude: 126,
     zoom: 15,
   });
-  const [marker, setMarker] = useState({ latitude: 37, longitude: 126 });
 
   useEffect(() => {
     setViewport({
@@ -28,20 +24,16 @@ const Map = ({ latitude, longitude, onChangeLocation }: Props) => {
       longitude,
     });
 
-    setMarker({
+    onChangeMarker({
       latitude,
       longitude,
     });
   }, [latitude, longitude]);
 
   const onMarkerDragEnd = useCallback((event) => {
-    setMarker({
-      longitude: event.lngLat[0],
+    onChangeMarker({
       latitude: event.lngLat[1],
-    });
-    onChangeLocation({
       longitude: event.lngLat[0],
-      latitude: event.lngLat[1],
     });
   }, []);
   return (

--- a/src/pages/CreatePostPage/Map.tsx
+++ b/src/pages/CreatePostPage/Map.tsx
@@ -3,6 +3,7 @@ import MapGl, { Marker } from 'react-map-gl';
 import Pin from './Pin';
 import { Location } from './types';
 
+const MAP_STYLE = 'mapbox://styles/mapbox/light-v10';
 interface Props {
   latitude: number;
   longitude: number;
@@ -41,7 +42,7 @@ const Map = ({ latitude, longitude, marker, onChangeMarker }: Props) => {
       {...viewport}
       width="100%"
       height="100%"
-      mapStyle="mapbox://styles/mapbox/light-v10"
+      mapStyle={MAP_STYLE}
       onViewportChange={setViewport}
       mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_TOKEN}
     >

--- a/src/pages/CreatePostPage/Map.tsx
+++ b/src/pages/CreatePostPage/Map.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import MapGl, { Marker } from 'react-map-gl';
+import { MAP_STYLE } from '../../utils/constants/mapConstants';
 import Pin from './Pin';
 import { Location } from './types';
 
-const MAP_STYLE = 'mapbox://styles/mapbox/light-v10';
 interface Props {
   latitude: number;
   longitude: number;

--- a/src/pages/CreatePostPage/SecondStep.tsx
+++ b/src/pages/CreatePostPage/SecondStep.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, useEffect, useState } from 'react';
-import { Text, Button } from '../../components/atoms';
+import { Text } from '../../components/atoms';
 import {
   NextStepButton,
   PreviewImg,
@@ -10,6 +10,8 @@ import {
   FormContentWrapper,
   PostFormContainer,
   SecondStepContainer,
+  UploadTextWrapper,
+  DeleteImgButton,
 } from './style';
 import { SecondStepData } from './types';
 
@@ -92,7 +94,10 @@ const SecondStep = ({ goNextStep, goPrevStep, handleSecondStepData }: Props) => 
           ></FormInput>
         </FormContentWrapper>
         <FormContentWrapper>
-          <Text textType="Heading4">사진 업로드</Text>
+          <UploadTextWrapper>
+            <Text textType="Heading4">사진 업로드</Text>
+            <DeleteImgButton>사진 삭제</DeleteImgButton>
+          </UploadTextWrapper>
           <ImageUpload
             droppable
             name="image"

--- a/src/pages/CreatePostPage/SecondStep.tsx
+++ b/src/pages/CreatePostPage/SecondStep.tsx
@@ -34,8 +34,13 @@ const SecondStep = ({ goNextStep, goPrevStep, handleSecondStepData }: Props) => 
     }));
   };
 
-  const handleImageFile = (file: File) => {
+  const handleSetImageFile = (file: File) => {
     setFile(file);
+  };
+
+  const handleDeleteImageFile = () => {
+    setFile(undefined);
+    setImageURL('');
   };
 
   const FileToDataURL = (file: File) => {
@@ -96,13 +101,13 @@ const SecondStep = ({ goNextStep, goPrevStep, handleSecondStepData }: Props) => 
         <FormContentWrapper>
           <UploadTextWrapper>
             <Text textType="Heading4">사진 업로드</Text>
-            <DeleteImgButton>사진 삭제</DeleteImgButton>
+            <DeleteImgButton onClick={handleDeleteImageFile}>사진 삭제</DeleteImgButton>
           </UploadTextWrapper>
           <ImageUpload
             droppable
             name="image"
             accept="image/*"
-            onChange={handleImageFile}
+            onChange={handleSetImageFile}
             imageURL={imageURL}
           >
             <ImageUploadIcon imageURL={imageURL}>+</ImageUploadIcon>

--- a/src/pages/CreatePostPage/SecondStep.tsx
+++ b/src/pages/CreatePostPage/SecondStep.tsx
@@ -1,0 +1,133 @@
+import React, { ChangeEvent, useEffect, useState } from 'react';
+import { Text } from '../../components/atoms';
+import {
+  NextStepButton,
+  PreviewImg,
+  ImageUpload,
+  ImageUploadIcon,
+  FormTextArea,
+  FormInput,
+  FormContentWrapper,
+  PostFormContainer,
+  SecondStepContainer,
+} from './style';
+import { SecondStepData } from './types';
+
+interface Props {
+  goNextStep(): void;
+  goPrevStep(): void;
+  handleSecondStepData(obj: SecondStepData): void;
+}
+
+const SecondStep = ({ goNextStep, goPrevStep, handleSecondStepData }: Props) => {
+  const [imageURL, setImageURL] = useState('');
+  const [file, setFile] = useState<File>();
+  const [title, setTitle] = useState('');
+  const [previewText, setPreviewText] = useState('');
+  const [content, setContent] = useState('');
+
+  const handleTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setTitle(e.target.value);
+  };
+
+  const handlePreviewTextChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setPreviewText(e.target.value);
+  };
+
+  const handleContentChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setContent(e.target.value);
+  };
+
+  const handleImageFile = (file: File) => {
+    setFile(file);
+  };
+
+  const FileToDataURL = (file: File) => {
+    const reader = new FileReader();
+
+    if (file) {
+      reader.readAsDataURL(file);
+      reader.onload = (e) => {
+        setImageURL(e.target?.result as string);
+      };
+    } else {
+      setImageURL('');
+    }
+  };
+
+  useEffect(() => {
+    file && FileToDataURL(file);
+  }, [file]);
+
+  const checkForm = () => {
+    if (!(file || content)) {
+      return false;
+    }
+    return true;
+  };
+
+  const saveFormData = () => {
+    const data = { imageFiles: [file], title, previewText, content };
+    handleSecondStepData(data);
+    goNextStep();
+  };
+
+  return (
+    <SecondStepContainer>
+      <button onClick={goPrevStep}>뒤로가기</button>
+      <PostFormContainer>
+        <Text textType="Heading3">필름에 내용을 담아주세요</Text>
+        <FormContentWrapper>
+          <Text textType="Heading4">필름 이름</Text>
+          <FormInput
+            value={title}
+            onChange={handleTitleChange}
+            placeholder={'최대 20자까지 작성 가능합니다.'}
+            maxLength={20}
+          ></FormInput>
+        </FormContentWrapper>
+        <FormContentWrapper>
+          <Text textType="Heading4">엿보기 문구</Text>
+          <FormInput
+            value={previewText}
+            onChange={handlePreviewTextChange}
+            placeholder={'최대 30자까지 작성 가능합니다.'}
+            maxLength={30}
+          ></FormInput>
+        </FormContentWrapper>
+        <FormContentWrapper>
+          <Text textType="Heading4">사진 업로드</Text>
+          <ImageUpload
+            droppable
+            name="image"
+            accept="image/*"
+            onChange={handleImageFile}
+            imageURL={imageURL}
+          >
+            <ImageUploadIcon imageURL={imageURL}>+</ImageUploadIcon>
+            {imageURL ? <PreviewImg src={imageURL} /> : ''}
+          </ImageUpload>
+        </FormContentWrapper>
+        <FormContentWrapper>
+          <Text textType="Heading4">내용 작성</Text>
+          <FormTextArea
+            value={content}
+            onChange={handleContentChange}
+            placeholder={'최대 1000자까지 작성 가능합니다.'}
+            maxLength={1000}
+          ></FormTextArea>
+        </FormContentWrapper>
+      </PostFormContainer>
+      <NextStepButton
+        buttonType="PrimaryBtn"
+        onClick={() => {
+          checkForm() ? saveFormData() : alert('이미지를 업로드 하거나 내용을 입력해주세요');
+        }}
+      >
+        <Text textType="Paragraph1">다음</Text>
+      </NextStepButton>
+    </SecondStepContainer>
+  );
+};
+
+export default SecondStep;

--- a/src/pages/CreatePostPage/SecondStep.tsx
+++ b/src/pages/CreatePostPage/SecondStep.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, useEffect, useState } from 'react';
-import { Text } from '../../components/atoms';
+import { Text, Button } from '../../components/atoms';
 import {
   NextStepButton,
   PreviewImg,
@@ -22,20 +22,14 @@ interface Props {
 const SecondStep = ({ goNextStep, goPrevStep, handleSecondStepData }: Props) => {
   const [imageURL, setImageURL] = useState('');
   const [file, setFile] = useState<File>();
-  const [title, setTitle] = useState('');
-  const [previewText, setPreviewText] = useState('');
-  const [content, setContent] = useState('');
+  const [state, setState] = useState({ title: '', previewText: '', content: '' });
 
-  const handleTitleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setTitle(e.target.value);
-  };
-
-  const handlePreviewTextChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setPreviewText(e.target.value);
-  };
-
-  const handleContentChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    setContent(e.target.value);
+  const handleInput = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setState((prevState) => ({
+      ...prevState,
+      [name]: value,
+    }));
   };
 
   const handleImageFile = (file: File) => {
@@ -60,14 +54,14 @@ const SecondStep = ({ goNextStep, goPrevStep, handleSecondStepData }: Props) => 
   }, [file]);
 
   const checkForm = () => {
-    if (!(file || content)) {
+    if (!(file || state.content)) {
       return false;
     }
     return true;
   };
 
   const saveFormData = () => {
-    const data = { imageFiles: [file], title, previewText, content };
+    const data = { ...state, imageFiles: [file] };
     handleSecondStepData(data);
     goNextStep();
   };
@@ -80,8 +74,9 @@ const SecondStep = ({ goNextStep, goPrevStep, handleSecondStepData }: Props) => 
         <FormContentWrapper>
           <Text textType="Heading4">필름 이름</Text>
           <FormInput
-            value={title}
-            onChange={handleTitleChange}
+            name="title"
+            value={state.title}
+            onChange={handleInput}
             placeholder={'최대 20자까지 작성 가능합니다.'}
             maxLength={20}
           ></FormInput>
@@ -89,8 +84,9 @@ const SecondStep = ({ goNextStep, goPrevStep, handleSecondStepData }: Props) => 
         <FormContentWrapper>
           <Text textType="Heading4">엿보기 문구</Text>
           <FormInput
-            value={previewText}
-            onChange={handlePreviewTextChange}
+            name="previewText"
+            value={state.previewText}
+            onChange={handleInput}
             placeholder={'최대 30자까지 작성 가능합니다.'}
             maxLength={30}
           ></FormInput>
@@ -111,8 +107,9 @@ const SecondStep = ({ goNextStep, goPrevStep, handleSecondStepData }: Props) => 
         <FormContentWrapper>
           <Text textType="Heading4">내용 작성</Text>
           <FormTextArea
-            value={content}
-            onChange={handleContentChange}
+            name="content"
+            value={state.content}
+            onChange={handleInput}
             placeholder={'최대 1000자까지 작성 가능합니다.'}
             maxLength={1000}
           ></FormTextArea>

--- a/src/pages/CreatePostPage/index.tsx
+++ b/src/pages/CreatePostPage/index.tsx
@@ -1,45 +1,62 @@
 import { useEffect, useState } from 'react';
-import Map from './Map';
-import { CreatePostPageContainer, FirstStepButton, MapHeaderText } from './style';
-import { Text } from '../../components/atoms';
+import { CreatePostPageContainer } from './style';
+import FirstStep from './FirstStep';
+import SecondStep from './SecondStep';
+import { SecondStepData, Location } from './types';
 
 const CreatePostPage = () => {
-  const [userLocation, setUserLocation] = useState({ latitude: 37, longitude: 127 });
-  const [selectedLocation, setSelectedLocation] = useState({ latitude: 37, longitude: 127 });
+  const [step, setStep] = useState(1);
+  const [location, setLocation] = useState<Location | null>(null);
+  const [secondStepData, setSecondStepData] = useState({});
 
-  useEffect(() => {
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition((position) => {
-        setUserLocation({
-          latitude: position.coords.latitude,
-          longitude: position.coords.longitude,
-        });
-      });
-    } else {
-      console.warn('GPS를 지원하지 않습니다.');
+  const goNextStep = () => {
+    if (step === 4) {
+      return;
     }
-  }, []);
+    setStep((prev) => prev + 1);
+  };
+
+  const goPrevStep = () => {
+    if (step === 1) {
+      return;
+    }
+    setStep((prev) => prev - 1);
+  };
+
+  const handleSecondStepData = (data: SecondStepData) => {
+    setSecondStepData(data);
+  };
+
+  const handleLocation = (data: Location) => {
+    setLocation(data);
+  };
 
   useEffect(() => {
-    console.log('마커 위치 정보');
-    console.log(selectedLocation);
-  }, [selectedLocation]);
+    console.log('유저 위치 정보');
+    console.log([location]);
+  }, [location]);
+
+  useEffect(() => {
+    console.log('유저 입력 데이터 정보');
+    console.log(secondStepData);
+  }, [secondStepData]);
+
+  useEffect(() => {
+    console.log('스텝 정보');
+    console.log(step);
+  }, [step]);
 
   return (
     <CreatePostPageContainer>
-      <MapHeaderText textType="Heading3">
-        필름을 맡길
-        <br />
-        위치로 마커를 옮겨주세요
-      </MapHeaderText>
-      <Map
-        latitude={userLocation.latitude}
-        longitude={userLocation.longitude}
-        onChangeLocation={setSelectedLocation}
-      />
-      <FirstStepButton buttonType="PrimaryBtn">
-        <Text textType="Paragraph1">여기에 만들래요</Text>
-      </FirstStepButton>
+      {step === 1 ? (
+        <FirstStep goNextStep={goNextStep} location={location} handleLocation={handleLocation} />
+      ) : (
+        <SecondStep
+          goNextStep={goNextStep}
+          goPrevStep={goPrevStep}
+          handleSecondStepData={handleSecondStepData}
+        />
+      )}
     </CreatePostPageContainer>
   );
 };

--- a/src/pages/CreatePostPage/style.ts
+++ b/src/pages/CreatePostPage/style.ts
@@ -2,7 +2,12 @@ import styled from '@emotion/styled';
 import { Text, Button, Upload } from '../../components/atoms';
 
 const DeleteImgButton = styled(Button)`
+  height: 24px;
+  line-height: 0;
+  border: none;
+  color: ${({ theme }) => theme.colors.gray700};
   background-color: ${({ theme }) => theme.colors.gray200};
+  cursor: pointer;
 `;
 
 const UploadTextWrapper = styled.div`

--- a/src/pages/CreatePostPage/style.ts
+++ b/src/pages/CreatePostPage/style.ts
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled';
-import { Text, Button } from '../../components/atoms';
+import { Text, Button, Upload } from '../../components/atoms';
 
 const CreatePostPageContainer = styled.div`
   width: 100vw;
   height: 100vh;
   position: relative;
 `;
-const FirstStepButton = styled(Button)`
-  position: absolute;
+const NextStepButton = styled(Button)`
+  position: sticky;
   bottom: 0;
   width: 100%;
   z-index: 1000;
@@ -19,4 +19,90 @@ const MapHeaderText = styled(Text)`
   z-index: 1000;
 `;
 
-export { CreatePostPageContainer, FirstStepButton, MapHeaderText };
+const PreviewImg = styled.img`
+  width: 100%;
+`;
+const ImageUpload = styled(Upload)<{ imageURL: string }>`
+  border-radius: 4px;
+  position: relative;
+  border: ${({ imageURL }) => (imageURL ? 'none' : '1px solid')};
+  width: 100%;
+  height: ${({ imageURL }) => (imageURL ? 'auto' : '299px')};
+  box-sizing: border-box;
+`;
+
+const ImageUploadIcon = styled.div<{ imageURL: string }>`
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 100px;
+  color: ${({ imageURL, theme }) => (imageURL ? theme.colors.gray300 : theme.colors.gray700)};
+`;
+
+const FormTextArea = styled.textarea`
+  ${({ theme }) => theme.fonts.Paragraph1};
+  resize: none;
+  height: 299px;
+  padding: 16px;
+  border-radius: 4px;
+  border-color: ${({ theme }) => theme.colors.gray400};
+  border-style: solid;
+  ::placeholder {
+    color: ${({ theme }) => theme.colors.gray500};
+  }
+  box-sizing: border-box;
+`;
+
+const FormInput = styled.input`
+  ${({ theme }) => theme.fonts.Paragraph1};
+  padding: 0 16px 0 16px;
+  height: 48px;
+  border-radius: 4px;
+  border-color: ${({ theme }) => theme.colors.gray400};
+  border-style: solid;
+  ::placeholder {
+    color: ${({ theme }) => theme.colors.gray500};
+  }
+  box-sizing: border-box;
+`;
+
+const FormContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-sizing: border-box;
+`;
+
+const PostFormContainer = styled.div`
+  margin: 84px 24px 24px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  align-content: center;
+  box-sizing: border-box;
+`;
+
+const SecondStepContainer = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+`;
+
+export {
+  CreatePostPageContainer,
+  NextStepButton,
+  MapHeaderText,
+  PreviewImg,
+  ImageUpload,
+  ImageUploadIcon,
+  FormTextArea,
+  FormInput,
+  FormContentWrapper,
+  PostFormContainer,
+  SecondStepContainer,
+};

--- a/src/pages/CreatePostPage/style.ts
+++ b/src/pages/CreatePostPage/style.ts
@@ -1,6 +1,15 @@
 import styled from '@emotion/styled';
 import { Text, Button, Upload } from '../../components/atoms';
 
+const DeleteImgButton = styled(Button)`
+  background-color: ${({ theme }) => theme.colors.gray200};
+`;
+
+const UploadTextWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
 const CreatePostPageContainer = styled.div`
   width: 100vw;
   height: 100vh;
@@ -105,4 +114,6 @@ export {
   FormContentWrapper,
   PostFormContainer,
   SecondStepContainer,
+  UploadTextWrapper,
+  DeleteImgButton,
 };

--- a/src/pages/CreatePostPage/style.ts
+++ b/src/pages/CreatePostPage/style.ts
@@ -10,13 +10,13 @@ const NextStepButton = styled(Button)`
   position: sticky;
   bottom: 0;
   width: 100%;
-  z-index: 1000;
+  z-index: 1;
 `;
 const MapHeaderText = styled(Text)`
   position: absolute;
   top: 84px;
   left: 23px;
-  z-index: 1000;
+  z-index: 1;
 `;
 
 const PreviewImg = styled.img`

--- a/src/pages/CreatePostPage/types.ts
+++ b/src/pages/CreatePostPage/types.ts
@@ -1,0 +1,11 @@
+export interface SecondStepData {
+  imageFiles: (File | undefined)[];
+  title: string;
+  previewText: string;
+  content: string;
+}
+
+export interface Location {
+  latitude: number;
+  longitude: number;
+}

--- a/src/utils/constants/mapConstants.ts
+++ b/src/utils/constants/mapConstants.ts
@@ -1,0 +1,1 @@
+export const MAP_STYLE = 'mapbox://styles/mapbox/light-v10';


### PR DESCRIPTION
## 📝 작업한 내용
1. 기존의 페이지를 step에 따라 FirstStep, SecondStep으로 나눠서 출력하는 방식으로 변경 하였습니다.
3. SecondStep에 CreatePostPage의 필름 내용 입력 페이지를 작성 하였습니다.
4. Upload 컴포넌트의 onChange 타입을 수정 했습니다.
## 📌 리뷰 시 참고 사항

1. 작동 방식
- index에서 step에 따라 FirstStep SecontStep 페이지를 보여줍니다.
- 다음 단계로 넘어가는 버튼을 클릭 하면 step이 1증가하고, 유저가 선택한 위치 정보, 필름의 내용이 index로 넘어옵니다
 ( console.log로 확인중입니다.)
2. 현재 사진이나 내용이 둘 다 없다면 입력 해주세요 문구를 Toast가 없어서 alert으로 띄웁니다. 
3. navigation을 달아두지 않아서 뒤로가기 버튼을 임시로 만들어 두었습니다.
4. 한번에 올린 변경사항이 많아서 죄송합니다..
## 📷 화면 사진
![image](https://user-images.githubusercontent.com/68111046/145257942-6ed73fce-3fa8-42fb-838f-57e4b6f6a920.png)
![image](https://user-images.githubusercontent.com/68111046/145257791-e4a17794-2b4f-4726-85e1-6cd8717236da.png)

