### PR TITLE
[Film/#37] 아바타, 아바타 그룹 컴포넌트 생성

### DIFF
--- a/src/components/atoms/Avatar/AvatarGroup.tsx
+++ b/src/components/atoms/Avatar/AvatarGroup.tsx
@@ -1,17 +1,33 @@
-import React, { ReactNode } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
+import styled from '@emotion/styled';
 import { VALID_AVATAR } from './constants';
 
 interface Props {
   children: ReactNode;
+  overlapPx?: number;
 }
 
-const AvatarGroup = ({ children }: Props) => {
-  const avatars = React.Children.toArray(children).filter((element: ReactNode) => {
-    if (React.isValidElement(element) && element.props.__TYPE === VALID_AVATAR) {
-      return true;
-    }
-    return false;
-  });
-  return <div>{children}</div>;
+const AvatarGroup = ({ children, overlapPx = 0 }: Props) => {
+  const avatars = React.Children.toArray(children)
+    .filter((element: ReactNode) => {
+      if (React.isValidElement(element) && element.props.__TYPE === VALID_AVATAR) {
+        return true;
+      }
+      return false;
+    })
+    .map((avatar, index, avatars) => {
+      const item = avatar as ReactElement;
+      return React.cloneElement(item, {
+        ...item.props,
+        style: {
+          marginLeft: `${index === 0 ? 0 : -overlapPx}px`,
+          zIndex: avatars.length - index,
+        },
+      });
+    });
+  return <div>{avatars}</div>;
 };
+const Div = styled.div`
+  display: flex;
+`;
 export default AvatarGroup;

--- a/src/components/atoms/Avatar/AvatarGroup.tsx
+++ b/src/components/atoms/Avatar/AvatarGroup.tsx
@@ -1,0 +1,17 @@
+import React, { ReactNode } from 'react';
+import { VALID_AVATAR } from './constants';
+
+interface Props {
+  children: ReactNode;
+}
+
+const AvatarGroup = ({ children }: Props) => {
+  const avatars = React.Children.toArray(children).filter((element: ReactNode) => {
+    if (React.isValidElement(element) && element.props.__TYPE === VALID_AVATAR) {
+      return true;
+    }
+    return false;
+  });
+  return <div>{children}</div>;
+};
+export default AvatarGroup;

--- a/src/components/atoms/Avatar/AvatarGroup.tsx
+++ b/src/components/atoms/Avatar/AvatarGroup.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, ReactNode } from 'react';
-import styled from '@emotion/styled';
 import { VALID_AVATAR } from './constants';
+import { AvatarGroupWrapper } from './style';
 
 interface Props {
   children: ReactNode;
@@ -25,9 +25,7 @@ const AvatarGroup = ({ children, overlapPx = 0 }: Props) => {
         },
       });
     });
-  return <div>{avatars}</div>;
+  return <AvatarGroupWrapper>{avatars}</AvatarGroupWrapper>;
 };
-const Div = styled.div`
-  display: flex;
-`;
+
 export default AvatarGroup;

--- a/src/components/atoms/Avatar/constants.ts
+++ b/src/components/atoms/Avatar/constants.ts
@@ -1,0 +1,1 @@
+export const VALID_AVATAR = 'AVATAR';

--- a/src/components/atoms/Avatar/index.tsx
+++ b/src/components/atoms/Avatar/index.tsx
@@ -1,5 +1,7 @@
+import AvatarGroup from './AvatarGroup';
 import { RoundImg } from './style';
-
+import PropTypes from 'prop-types';
+import { VALID_AVATAR } from './constants';
 interface Props {
   size: number;
   src: string;
@@ -23,4 +25,9 @@ const Avatar = ({ lazy = false, size, src, alt, threshold = 0, placeholder = '' 
   );
 };
 
+Avatar.defaultProps = {
+  __TYPE: VALID_AVATAR,
+};
+
+Avatar.Group = AvatarGroup;
 export default Avatar;

--- a/src/components/atoms/Avatar/index.tsx
+++ b/src/components/atoms/Avatar/index.tsx
@@ -1,0 +1,26 @@
+import { RoundImg } from './style';
+
+interface Props {
+  size: number;
+  src: string;
+  alt: string;
+  lazy?: boolean;
+  threshold?: number;
+  placeholder?: string;
+}
+
+const Avatar = ({ lazy = false, size, src, alt, threshold = 0, placeholder = '' }: Props) => {
+  return (
+    <RoundImg
+      lazy={lazy}
+      threshold={threshold}
+      src={src}
+      alt={alt}
+      placeholder={placeholder}
+      height={size}
+      width={size}
+    />
+  );
+};
+
+export default Avatar;

--- a/src/components/atoms/Avatar/index.tsx
+++ b/src/components/atoms/Avatar/index.tsx
@@ -1,7 +1,7 @@
 import AvatarGroup from './AvatarGroup';
 import { RoundImg } from './style';
-import PropTypes from 'prop-types';
 import { VALID_AVATAR } from './constants';
+
 interface Props {
   size: number;
   src: string;
@@ -9,11 +9,23 @@ interface Props {
   lazy?: boolean;
   threshold?: number;
   placeholder?: string;
+  block?: boolean;
+  [x: string]: any;
 }
 
-const Avatar = ({ lazy = false, size, src, alt, threshold = 0, placeholder = '' }: Props) => {
+const Avatar = ({
+  lazy = false,
+  size,
+  src,
+  alt,
+  threshold = 0,
+  placeholder = '',
+  block,
+  ...props
+}: Props) => {
   return (
     <RoundImg
+      {...props}
       lazy={lazy}
       threshold={threshold}
       src={src}
@@ -21,6 +33,7 @@ const Avatar = ({ lazy = false, size, src, alt, threshold = 0, placeholder = '' 
       placeholder={placeholder}
       height={size}
       width={size}
+      block={block}
     />
   );
 };

--- a/src/components/atoms/Avatar/style.ts
+++ b/src/components/atoms/Avatar/style.ts
@@ -1,0 +1,7 @@
+import styled from '@emotion/styled';
+import { Image } from '..';
+
+const RoundImg = styled(Image)`
+  border-radius: 50%;
+`;
+export { RoundImg };

--- a/src/components/atoms/Avatar/style.ts
+++ b/src/components/atoms/Avatar/style.ts
@@ -4,4 +4,7 @@ import { Image } from '..';
 const RoundImg = styled(Image)`
   border-radius: 50%;
 `;
-export { RoundImg };
+const AvatarGroupWrapper = styled.div`
+  display: flex;
+`;
+export { RoundImg, AvatarGroupWrapper };

--- a/src/components/atoms/Image/index.tsx
+++ b/src/components/atoms/Image/index.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import { useInterSectionObserver } from './useInterSectingObserver';
 import { Img } from './style';
+
 interface Props {
   lazy?: boolean;
   threshold?: number;
@@ -10,6 +11,7 @@ interface Props {
   width: number;
   height: number;
   block?: boolean;
+  [x: string]: any;
 }
 
 let observer: IntersectionObserver;

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -4,3 +4,4 @@ export { default as Upload } from './Upload';
 export { default as Modal } from './Modal';
 export { default as Navigation } from '../atoms/Navigation';
 export { default as Image } from './Image';
+export { default as Avatar } from './Avatar';


### PR DESCRIPTION
## 📝 작업한 내용
아바타와 아바타 그룹을 만들었습니다.

## 📌 리뷰 시 참고 사항
- 아바타는 이미지컴포넌트에 의존하고 있습니다.
- 아바타 그룹을 만들때에는 `overlapPx`속성을 통해서 아바타끼리 겹치는 정도를 설정할 수 있습니다.

## ♻️재리뷰 참고 사항
- AvtarGroup 컴포넌트에서 default로 가로로 정렬이 되도록했습니다!
- Avatar의 경우는 block으로 사용될 경우가 많을것 같아 유지하되 AvatarGroup에 wrapper를 만들어 주었습니다

closes #37 