### PR TITLE
[Film/#16] 회원가입 페이지 만들기

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "axios": "^0.24.0",
+    "qs": "^6.10.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.3.1",

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -1,6 +1,10 @@
 import { Container, Wrapper, Text, Img, Button } from './style';
 import LoginWallPaper from '../../assets/LoginPage/LoginWallPaper.jpeg';
+
 const LogInPage = () => {
+  const handleBtnClick = () => {
+    location.href = process.env.REACT_APP_REDIRECT_URI as string;
+  };
   return (
     <Wrapper>
       <Container>
@@ -8,7 +12,7 @@ const LogInPage = () => {
           당신의 순간을 <br /> 그대로 남겨보세요
         </Text>
         <Img src={LoginWallPaper} alt="로그인 페이지 이미지" />
-        <Button>카카오로 3초만에 시작하기</Button>
+        <Button onClick={handleBtnClick}>카카오로 3초만에 시작하기</Button>
       </Container>
     </Wrapper>
   );

--- a/src/pages/OauthPage/index.tsx
+++ b/src/pages/OauthPage/index.tsx
@@ -1,19 +1,26 @@
-import { useEffect } from 'react';
+import React, { useCallback, useLayoutEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import qs from 'qs';
+import { isUserSignUpApi } from '../../utils/apis/user';
 
 const OauthPage = () => {
   const test = useLocation();
   const navigate = useNavigate();
+  const routingBasedOnSignUpStatus = useCallback(async (token: string) => {
+    const isSignUp = await isUserSignUpApi(token as string);
 
-  const { token } = qs.parse(test.search, {
-    ignoreQueryPrefix: true,
-  });
-
-  localStorage.setItem('token', JSON.stringify(token));
-
-  useEffect(() => {
+    if (isSignUp) {
+      return navigate('/');
+    }
     navigate('/signup');
+  }, []);
+
+  useLayoutEffect(() => {
+    const { token } = qs.parse(test.search, {
+      ignoreQueryPrefix: true,
+    });
+    localStorage.setItem('token', JSON.stringify(token));
+    routingBasedOnSignUpStatus(token as string);
   }, []);
   return <></>;
 };

--- a/src/pages/OauthPage/index.tsx
+++ b/src/pages/OauthPage/index.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import qs from 'qs';
+
+const OauthPage = () => {
+  const test = useLocation();
+  const navigate = useNavigate();
+
+  const { token } = qs.parse(test.search, {
+    ignoreQueryPrefix: true,
+  });
+
+  localStorage.setItem('token', JSON.stringify(token));
+
+  useEffect(() => {
+    navigate('/signup');
+  }, []);
+  return <></>;
+};
+
+export default OauthPage;

--- a/src/pages/SignUpPage/index.tsx
+++ b/src/pages/SignUpPage/index.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, FormEvent, useState } from 'react';
-import { Header, BackBtn, SignUpFormWrapper, Label, Input, FooterBtn } from './style';
+import { Header, BackBtn, SignUpFormWrapper, Label, Input, FooterBtn, ErrorText } from './style';
 import { BiLeftArrowAlt } from 'react-icons/bi';
 import { validateNickname } from './util';
 import { signUpApi } from '../../utils/apis/user';
@@ -40,7 +40,7 @@ const SignUpPage = () => {
           value={nickname}
           onChange={handleNicknameChange}
         />
-        {inpError}
+        <ErrorText>{inpError}</ErrorText>
         <FooterBtn type="submit">회원가입 완료</FooterBtn>
       </SignUpFormWrapper>
     </>

--- a/src/pages/SignUpPage/index.tsx
+++ b/src/pages/SignUpPage/index.tsx
@@ -2,6 +2,7 @@ import React, { ChangeEvent, FormEvent, useState } from 'react';
 import { Header, BackBtn, SignUpFormWrapper, Label, Input, FooterBtn } from './style';
 import { BiLeftArrowAlt } from 'react-icons/bi';
 import { validateNickname } from './util';
+import { signUpApi } from '../../utils/apis/user';
 
 const SignUpPage = () => {
   const [nickname, setNickname] = useState('');
@@ -17,7 +18,8 @@ const SignUpPage = () => {
     if (nicknameErrorMsg) {
       return setInpError(nicknameErrorMsg);
     }
-
+    const token = JSON.parse(localStorage.getItem('token') as string);
+    signUpApi(nickname, token);
     setNickname('');
     setInpError('');
   };

--- a/src/pages/SignUpPage/index.tsx
+++ b/src/pages/SignUpPage/index.tsx
@@ -1,7 +1,27 @@
-import React from 'react';
+import React, { ChangeEvent, FormEvent, useState } from 'react';
 import { Header, BackBtn, SignUpFormWrapper, Label, Input, FooterBtn } from './style';
 import { BiLeftArrowAlt } from 'react-icons/bi';
+import { validateNickname } from './util';
+
 const SignUpPage = () => {
+  const [nickname, setNickname] = useState('');
+  const [inpError, setInpError] = useState('');
+
+  const handleNicknameChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value);
+  };
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const nicknameErrorMsg = validateNickname(nickname);
+    if (nicknameErrorMsg) {
+      return setInpError(nicknameErrorMsg);
+    }
+
+    setNickname('');
+    setInpError('');
+  };
+
   return (
     <>
       <Header>
@@ -10,9 +30,15 @@ const SignUpPage = () => {
         </BackBtn>
         회원가입
       </Header>
-      <SignUpFormWrapper>
+      <SignUpFormWrapper onSubmit={handleSubmit}>
         <Label htmlFor="nickname">닉네임을 입력해 주세요</Label>
-        <Input id="nickname" placeholder="2자 이상, 20자 이하 문자, 숫자 가능" />
+        <Input
+          id="nickname"
+          placeholder="2자 이상, 20자 이하 문자, 숫자 가능"
+          value={nickname}
+          onChange={handleNicknameChange}
+        />
+        {inpError}
         <FooterBtn type="submit">회원가입 완료</FooterBtn>
       </SignUpFormWrapper>
     </>

--- a/src/pages/SignUpPage/style.ts
+++ b/src/pages/SignUpPage/style.ts
@@ -34,7 +34,10 @@ const Input = styled.input`
     outline: 1px solid black;
   }
 `;
-
+const ErrorText = styled.p`
+  margin: 10px 0;
+  color: red;
+`;
 const FooterBtn = styled.button`
   position: absolute;
   left: 50%;
@@ -48,4 +51,4 @@ const FooterBtn = styled.button`
   border-radius: 4px;
   cursor: pointer;
 `;
-export { Header, BackBtn, SignUpFormWrapper, Label, Input, FooterBtn };
+export { Header, BackBtn, SignUpFormWrapper, Label, Input, FooterBtn, ErrorText };

--- a/src/pages/SignUpPage/style.ts
+++ b/src/pages/SignUpPage/style.ts
@@ -34,20 +34,18 @@ const Input = styled.input`
     outline: 1px solid black;
   }
 `;
+
 const FooterBtn = styled.button`
-  margin-top: 400px;
-  width: 100%;
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  bottom: 0;
+  width: ${({ theme: { gaps } }) => `calc(100% - ${gaps.default_margin})`};
   height: 60px;
   border: none;
   background-color: black;
   color: white;
   border-radius: 4px;
   cursor: pointer;
-  @media (max-height: 700px) {
-    margin-top: 300px;
-  }
-  @media (max-height: 700px) {
-    margin-top: 220px;
-  }
 `;
 export { Header, BackBtn, SignUpFormWrapper, Label, Input, FooterBtn };

--- a/src/pages/SignUpPage/util.ts
+++ b/src/pages/SignUpPage/util.ts
@@ -1,0 +1,13 @@
+const validateNickname = (nickname: string) => {
+  const validateLogic = /^[A-Za-z0-9+]{2,20}$/;
+
+  if (nickname.length < 2 || nickname.length > 20) {
+    return '닉네임은 2자 이상 20자 이하여야 합니다.';
+  }
+  if (!validateLogic.test(nickname)) {
+    return '영어와 숫자만 가능합니다!';
+  }
+  return;
+};
+
+export { validateNickname };

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,4 +1,5 @@
 export { default as LogInPage } from './LoginPage';
-export { default as SignUnPage } from './SignUpPage';
+export { default as OauthPage } from './OauthPage';
 export { default as HomePage } from './HomePage';
 export { default as CreatePostPage } from './CreatePostPage';
+export { default as SignUpPage } from './SignUpPage';

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,12 +1,14 @@
 import { Route, Routes } from 'react-router-dom';
-import { LogInPage, HomePage, CreatePostPage } from '../pages';
+import { LogInPage, HomePage, OauthPage, CreatePostPage, SignUpPage } from '../pages';
 
 const Router = () => {
   return (
     <Routes>
       <Route path="/*" element={<HomePage />} />
-      <Route path="login" element={<LogInPage />} />
-      <Route path="post/create" element={<CreatePostPage />} />
+      <Route path="/oauth/redirect/*" element={<OauthPage />} />
+      <Route path="/login" element={<LogInPage />} />
+      <Route path="/signup" element={<SignUpPage />} />
+      <Route path="/post/create" element={<CreatePostPage />} />
     </Routes>
   );
 };

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,5 +1,5 @@
 import { Route, Routes } from 'react-router-dom';
-import { CreatePostPage, LogInPage, HomePage } from '../pages';
+import { LogInPage, HomePage, CreatePostPage } from '../pages';
 
 const Router = () => {
   return (

--- a/src/utils/apis/user.ts
+++ b/src/utils/apis/user.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+const isUserSignUpApi = async (token: string) => {
+  try {
+    const { data: isSignUp } = await axios.get(
+      `${process.env.REACT_APP_BASE_URL}/api/v1/users/duplicate`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+    return isSignUp;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export { isUserSignUpApi };

--- a/src/utils/apis/user.ts
+++ b/src/utils/apis/user.ts
@@ -19,7 +19,7 @@ const isUserSignUpApi = async (token: string) => {
 const signUpApi = async (nickname: string, token: string) => {
   try {
     const res = await axios.post(
-      `${process.env.BASE_URL}/api/v1/users/signup`,
+      `${process.env.REACT_APP_BASE_URL}/api/v1/users/signup`,
       {
         nickname,
       },

--- a/src/utils/apis/user.ts
+++ b/src/utils/apis/user.ts
@@ -16,4 +16,22 @@ const isUserSignUpApi = async (token: string) => {
   }
 };
 
-export { isUserSignUpApi };
+const signUpApi = async (nickname: string, token: string) => {
+  try {
+    const res = await axios.post(
+      `${process.env.BASE_URL}/api/v1/users/signup`,
+      {
+        nickname,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+    console.log(res, 'res');
+  } catch ({ response }) {
+    console.log(response);
+  }
+};
+export { isUserSignUpApi, signUpApi };

--- a/yarn.lock
+++ b/yarn.lock
@@ -12393,6 +12393,13 @@ qs@^6.10.0:
   dependencies:
     side-channel "^1.0.4"
 
+qs@^6.10.2:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.2.tgz#c1431bea37fc5b24c5bdbafa20f16bdf2a4b9ffe"
+  integrity sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==
+  dependencies:
+    side-channel "^1.0.4"
+
 query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"


### PR DESCRIPTION
## 📝 작업한 내용

로그인 페이지 제작

1. /login페이지로 진입한다.
2. 토큰이 없거나(서비스를 처음 사용하는 경우) 만료되었을 경우 카카오 로그인페이지로 리다이렉트된다.
3. 처음 회원가입하는 경우 닉네임 입력페이지로 이동한다.
4. / 홈으로 이동한다.

## 📌 리뷰 시 참고 사항

1. 아직 userInfo 데이터가 완벽히 들어오는것이 아니라 추후에 contextApi를 붙일 예정입니다.
2. axios interceptor로 헤더를 붙여주는 부분을 해야할것 같습니다.
3. localstorage에서 토큰을 가져오는 부분을 만들어야할것 같습니다
4. 회원가입의 푸터의 경우 모바일에서 input에 focus되었을 때 `positoin: absolute라면 ` 키보드 창이 올라올 때 동시에 footer도 올라오는 문제가 생겼습니다.
    - 따라서 `position: absolute`대신 Margin을 통해 하단에 위치하도록 하였는데, 이렇게 하니 기기에 따라 버튼의 위치가 모두 달라져 보기에 이상한것 같았습니다.
    - 그래서 다시 `position: absolute` 속성을 주었는데 여러분은 어떠한것이 더 좋은것 같나요?
5. 현재 kakao endpoint가 localhost로 되어있어 모바일에서는 되지 않습니다.(나머지 페이지는 문제 없습니다.)
6. 아직 회원가입 후 response data가 수정중이어서 리다이렉트 로직 & context api는 하지 않았습니다.

## 📷 화면 사진
![screencast 2021-12-12 20-49-32](https://user-images.githubusercontent.com/70435257/145711080-512f39d4-b638-4bda-9bd7-0ad42304d5a3.gif)

closes #16