### PR TITLE
[Film/#53] Homepage에서 Map 별도 파일로 분리

### DIFF
--- a/src/components/organism/Pin/index.tsx
+++ b/src/components/organism/Pin/index.tsx
@@ -10,8 +10,6 @@ interface PinProps {
   state: string;
 }
 const Pin = ({ selected, state, ...props }: PinProps) => {
-  console.log('pin');
-
   return (
     <div {...props}>
       {selected ? (

--- a/src/components/organism/Pin/index.tsx
+++ b/src/components/organism/Pin/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import PinOpen from '../../../assets/icons/icon_marker_open.svg';
 import PinClose from '../../../assets/icons/icon_marker_close.svg';
 import PinSelectedOpen from '../../../assets/icons/icon_marker_open_selected.svg';
@@ -9,6 +10,8 @@ interface PinProps {
   state: string;
 }
 const Pin = ({ selected, state, ...props }: PinProps) => {
+  console.log('pin');
+
   return (
     <div {...props}>
       {selected ? (
@@ -26,4 +29,4 @@ const Pin = ({ selected, state, ...props }: PinProps) => {
   );
 };
 
-export default Pin;
+export default React.memo(Pin);

--- a/src/pages/HomePage/Map.tsx
+++ b/src/pages/HomePage/Map.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import MapGL, { GeolocateControl, Marker } from 'react-map-gl';
 import { Pin } from '../../components/organism';
 
@@ -35,6 +35,7 @@ const Map = ({ location, postList }: Props) => {
   const positionOptions = { enableHighAccuracy: true };
 
   const { id } = useParams();
+  const navigate = useNavigate();
 
   useEffect(() => {
     !id ? setselectedMarker(null) : '';
@@ -72,14 +73,13 @@ const Map = ({ location, postList }: Props) => {
           longitude={parseFloat(data.location.longitude)}
           onClick={() => {
             handleSelectedMarker(data);
+            navigate(`${data.postId}`);
           }}
         >
-          <Link to={`${data.postId}`}>
-            <Pin
-              selected={selectedMarker?.postId === data.postId ? true : false}
-              state={data.state}
-            ></Pin>
-          </Link>
+          <Pin
+            selected={selectedMarker?.postId === data.postId ? true : false}
+            state={data.state}
+          ></Pin>
         </Marker>
       ))}
     </MapGL>

--- a/src/pages/HomePage/Map.tsx
+++ b/src/pages/HomePage/Map.tsx
@@ -41,7 +41,7 @@ const Map = ({ currentLocation, selectedPost, postList, onClick }: Props) => {
   const [viewport, setViewport] = useState({
     latitude: 37,
     longitude: 127,
-    zoom: 10,
+    zoom: 15,
     bearing: 0,
     pitch: 0,
   });

--- a/src/pages/HomePage/Map.tsx
+++ b/src/pages/HomePage/Map.tsx
@@ -1,0 +1,89 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import MapGL, { GeolocateControl, Marker } from 'react-map-gl';
+import { Pin } from '../../components/organism';
+
+interface Post {
+  postId: number;
+  state: string;
+  location: {
+    latitude: string;
+    longitude: string;
+  };
+}
+interface Props {
+  location?: {
+    latitude: string;
+    longitude: string;
+  };
+  postList: Post[];
+}
+const Map = ({ location, postList }: Props) => {
+  const [viewport, setViewport] = useState({
+    latitude: 37,
+    longitude: 127,
+    zoom: 10,
+    bearing: 0,
+    pitch: 0,
+  });
+  const [selectedMarker, setselectedMarker] = useState<Post | null>(null);
+
+  const handleSelectedMarker = useCallback((data: Post) => {
+    setselectedMarker(data);
+  }, []);
+
+  const positionOptions = { enableHighAccuracy: true };
+
+  const { id } = useParams();
+
+  useEffect(() => {
+    !id ? setselectedMarker(null) : '';
+  }, [id]);
+
+  useEffect(() => {
+    if (location) {
+      setViewport((prev) => ({
+        ...prev,
+        latitude: parseFloat(location.latitude),
+        longitude: parseFloat(location.longitude),
+      }));
+    }
+  }, []);
+
+  return (
+    <MapGL
+      {...viewport}
+      width="100vw"
+      height="100vh"
+      mapStyle="mapbox://styles/mapbox/light-v10"
+      onViewportChange={setViewport}
+      mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_TOKEN}
+    >
+      <GeolocateControl
+        style={{ top: 0, left: 0, margin: 10 }}
+        positionOptions={positionOptions}
+        trackUserLocation
+        auto
+      />
+      {postList.map((data, i) => (
+        <Marker
+          key={i}
+          latitude={parseFloat(data.location.latitude)}
+          longitude={parseFloat(data.location.longitude)}
+          onClick={() => {
+            handleSelectedMarker(data);
+          }}
+        >
+          <Link to={`${data.postId}`}>
+            <Pin
+              selected={selectedMarker?.postId === data.postId ? true : false}
+              state={data.state}
+            ></Pin>
+          </Link>
+        </Marker>
+      ))}
+    </MapGL>
+  );
+};
+
+export default Map;

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -1,38 +1,31 @@
-import { useState, useEffect, useCallback } from 'react';
-import MapGL, { GeolocateControl, Marker } from 'react-map-gl';
-import { useParams, Link, Route, Routes } from 'react-router-dom';
-import { Pin, PreviewBottomSheet } from '../../components/organism';
+import { Route, Routes } from 'react-router-dom';
+import { PreviewBottomSheet } from '../../components/organism';
+import Map from './Map';
 
 const dummy = [
   {
     postId: 0,
     state: 'Closed',
-    location: [
-      {
-        latitude: '37.491837217869616',
-        longitude: '127.02959879978368',
-      },
-    ],
+    location: {
+      latitude: '37.491837217869616',
+      longitude: '127.02959879978368',
+    },
   },
   {
     postId: 1,
     state: 'Opend',
-    location: [
-      {
-        latitude: '37.48802955953209',
-        longitude: '127.02570733476914',
-      },
-    ],
+    location: {
+      latitude: '37.48802955953209',
+      longitude: '127.02570733476914',
+    },
   },
   {
     postId: 2,
     state: 'Openable',
-    location: [
-      {
-        latitude: '37.48722960663839',
-        longitude: '127.0299415713133',
-      },
-    ],
+    location: {
+      latitude: '37.48722960663839',
+      longitude: '127.0299415713133',
+    },
   },
 ];
 const dummyPost = {
@@ -59,71 +52,11 @@ const dummyPost = {
     },
   ],
 };
-interface Location {
-  latitude: string;
-  longitude: string;
-}
-
-interface Post {
-  postId: number;
-  state: string;
-  location: Location[];
-}
 
 const HomePage = () => {
-  const [viewport, setViewport] = useState({
-    latitude: 37,
-    longitude: 127,
-    zoom: 5,
-    bearing: 0,
-    pitch: 0,
-  });
-  const [selectedMarker, setselectedMarker] = useState<Post | null>(null);
-  const { id } = useParams();
-  const handleSelectedMarker = useCallback((data: Post) => {
-    setselectedMarker(data);
-  }, []);
-
-  const positionOptions = { enableHighAccuracy: true };
-
-  useEffect(() => {
-    !id ? setselectedMarker(null) : '';
-  }, [id]);
-
   return (
     <div>
-      <MapGL
-        {...viewport}
-        width="100vw"
-        height="100vh"
-        mapStyle="mapbox://styles/mapbox/light-v10"
-        onViewportChange={setViewport}
-        mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_TOKEN}
-      >
-        <GeolocateControl
-          style={{ top: 0, left: 0, margin: 10 }}
-          positionOptions={positionOptions}
-          trackUserLocation
-          auto
-        />
-        {dummy.map((data, i) => (
-          <Marker
-            key={i}
-            latitude={parseFloat(data.location[0].latitude)}
-            longitude={parseFloat(data.location[0].longitude)}
-            onClick={() => {
-              handleSelectedMarker(data);
-            }}
-          >
-            <Link to={`${data.postId}`}>
-              <Pin
-                selected={selectedMarker?.postId === data.postId ? true : false}
-                state={data.state}
-              ></Pin>
-            </Link>
-          </Marker>
-        ))}
-      </MapGL>
+      <Map location={dummyPost.location} postList={dummy} />
       <Routes>
         <Route path=":id" element={<PreviewBottomSheet previewPost={dummyPost} />} />
       </Routes>

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -1,5 +1,7 @@
-import { Route, Routes } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import { PreviewBottomSheet } from '../../components/organism';
+
 import Map from './Map';
 
 const dummy = [
@@ -28,38 +30,126 @@ const dummy = [
     },
   },
 ];
-const dummyPost = {
-  postId: 0,
-  title: '제목입니당',
-  previewText: '엿보기 문구입니당',
-  availableAt: 'yyyy-MM-dd',
-  state: 'Closed',
-  location: {
-    latitude: '37.491837217869616',
-    longitude: '127.02959879978368',
+const PreviewPosts = [
+  {
+    postId: 0,
+    title: '제목입니당',
+    previewText: '엿보기 문구입니당',
+    availableAt: 'yyyy-MM-dd',
+    state: 'Closed',
+    location: {
+      latitude: '37.491837217869616',
+      longitude: '127.02959879978368',
+    },
+    authorityCount: 3,
+    authorityImageList: [
+      {
+        imageOrder: 0,
+        authorityId: 0,
+        imageUrl: '',
+      },
+      {
+        imageOrder: 0,
+        authorityId: 0,
+        imageUrl: '',
+      },
+    ],
   },
-  authorityCount: 3,
-  authorityImageList: [
-    {
-      imageOrder: 0,
-      authorityId: 0,
-      imageUrl: '',
+  {
+    postId: 1,
+    title: '제목입니당',
+    previewText: '엿보기 문구입니당',
+    availableAt: 'yyyy-MM-dd',
+    state: 'Closed',
+    location: {
+      latitude: '37.48802955953209',
+      longitude: '127.02570733476914',
     },
-    {
-      imageOrder: 0,
-      authorityId: 0,
-      imageUrl: '',
+    authorityCount: 3,
+    authorityImageList: [
+      {
+        imageOrder: 0,
+        authorityId: 0,
+        imageUrl: '',
+      },
+      {
+        imageOrder: 0,
+        authorityId: 0,
+        imageUrl: '',
+      },
+    ],
+  },
+  {
+    postId: 2,
+    title: '제목입니당',
+    previewText: '엿보기 문구입니당',
+    availableAt: 'yyyy-MM-dd',
+    state: 'Closed',
+    location: {
+      latitude: '37.48722960663839',
+      longitude: '127.0299415713133',
     },
-  ],
-};
+    authorityCount: 3,
+    authorityImageList: [
+      {
+        imageOrder: 0,
+        authorityId: 0,
+        imageUrl: '',
+      },
+      {
+        imageOrder: 0,
+        authorityId: 0,
+        imageUrl: '',
+      },
+    ],
+  },
+];
+interface PreviewPost {
+  postId: number;
+  title: string;
+  previewText: string;
+  availableAt: string;
+  state: string;
+  location: {
+    latitude: string;
+    longitude: string;
+  };
+  authorityCount: number;
+  authorityImageList: {
+    imageOrder: number;
+    authorityId: number;
+    imageUrl: string;
+  }[];
+}
 
 const HomePage = () => {
+  const { pathname } = useLocation();
+  const [selectedPost, setselectedPost] = useState<PreviewPost | null>(null);
+
+  const handleSelectedPost = (postid: number) => {
+    // 엿보기 페이지 api 통신
+    setselectedPost(PreviewPosts[postid]);
+  };
+
+  useEffect(() => {
+    pathname.slice(1) ? handleSelectedPost(parseInt(pathname.slice(1))) : setselectedPost(null);
+  }, [pathname]);
+
   return (
     <div>
-      <Map location={dummyPost.location} postList={dummy} />
-      <Routes>
-        <Route path=":id" element={<PreviewBottomSheet previewPost={dummyPost} />} />
-      </Routes>
+      <Map
+        currentLocation={!pathname.slice(1) ? true : false}
+        selectedPost={selectedPost}
+        postList={dummy}
+        onClick={handleSelectedPost}
+      />
+      {selectedPost ? (
+        <Routes>
+          <Route path=":id" element={<PreviewBottomSheet previewPost={selectedPost} />} />
+        </Routes>
+      ) : (
+        ''
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 📝 작업한 내용

- [x] Homepage에서 Map 별도 파일로 분리하여 지도가 리랜더링 될 경우, 다른 컴포넌트까지 리랜더링 되지 않도록 리팩토링
- [x] 상위 컴포넌트에서 선택된 포스트가 있으면, 해당 포스트 위치를 기준으로 지도 이동
- [x] 최초 렌더링 시, 특정 위치가 전달되지 않으면 현재위치를 기준으로 지도 띄우기

## 📌 리뷰 시 참고 사항
- 지도 하위에 사용되는 컴포넌트는 React.memo로 리랜더링을 방지해주면 좋을 것 같습니다!
- 일단 더미데이터로 작업되어 있습니다.(추후 변경할 예정입니다)

## 📷 화면 사진

https://user-images.githubusercontent.com/28250027/145773464-f8618627-677e-432c-bb6c-de60f4547b9b.mov

 