### PR TITLE
[film/#113] CreatePost에서 사진 업로드, 삭제 후 동일한 파일 업로드시 업데이트 되지 않던 현상 제거

### DIFF
--- a/src/components/atoms/Upload/index.tsx
+++ b/src/components/atoms/Upload/index.tsx
@@ -1,8 +1,17 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { UploadContainer, UploadInput } from './style';
 import { UploadProps } from './types';
 
-const Upload = ({ children, name, accept, droppable, value, onChange, ...props }: UploadProps) => {
+const Upload = ({
+  children,
+  name,
+  accept,
+  droppable,
+  value,
+  fileDelete,
+  onChange,
+  ...props
+}: UploadProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState(value);
   const [uploading, setUploading] = useState(false);
@@ -57,6 +66,15 @@ const Upload = ({ children, name, accept, droppable, value, onChange, ...props }
       onChange(changedFile);
     }
   }, []);
+
+  useEffect(() => {
+    if (!fileDelete) {
+      return;
+    }
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+  }, [fileDelete]);
 
   return (
     <UploadContainer

--- a/src/components/atoms/Upload/types.ts
+++ b/src/components/atoms/Upload/types.ts
@@ -7,4 +7,5 @@ export interface UploadProps {
   accept?: string;
   value?: File;
   droppable: boolean;
+  fileDelete?: boolean;
 }

--- a/src/pages/CreatePostPage/components/SecondStep/index.tsx
+++ b/src/pages/CreatePostPage/components/SecondStep/index.tsx
@@ -160,6 +160,7 @@ const SecondStep = ({
             accept="image/*"
             onChange={handleSetImageFile}
             imageURL={imageURL}
+            fileDelete={file ? false : true}
           >
             <ImageUploadIcon imageURL={imageURL}>+</ImageUploadIcon>
             {imageURL ? <PreviewImg src={imageURL} /> : ''}


### PR DESCRIPTION
## 📝 작업한 내용

CreatePost에서 사진 업로드, 삭제 후 동일한 파일 업로드 시 업데이트 되지 않던 현상 제거했습니다.

## 📷 화면 사진
![custom2](https://user-images.githubusercontent.com/68111046/146231014-f7e4ecc9-2f2e-49bd-9993-1fab26573ae5.gif)

