### PR TITLE
[film/#149] localstorage에 저장된 날짜가  내일 날짜보다 이전일 경우 내일로 수정하도록 변경

### DIFF
--- a/src/pages/CreatePostPage/components/ThirdStep/index.tsx
+++ b/src/pages/CreatePostPage/components/ThirdStep/index.tsx
@@ -51,6 +51,9 @@ const ThirdStep = ({
   };
 
   useEffect(() => {
+    if (!dateValidate(date)) {
+      return;
+    }
     const dateToArr = date?.split('-');
     if (dateToArr) {
       setState((prevState) => ({

--- a/src/pages/CreatePostPage/components/ThirdStep/index.tsx
+++ b/src/pages/CreatePostPage/components/ThirdStep/index.tsx
@@ -44,6 +44,12 @@ const ThirdStep = ({
     setDate(e.target.value);
   };
 
+  const dateValidate = (date: string) => {
+    const tomorrow = new Date();
+    const storedDate = new Date(date);
+    return tomorrow > storedDate ? false : true;
+  };
+
   useEffect(() => {
     const dateToArr = date?.split('-');
     if (dateToArr) {
@@ -57,7 +63,8 @@ const ThirdStep = ({
   }, [date]);
 
   useEffect(() => {
-    if (date) {
+    if (date && dateValidate(date)) {
+      setMinDay(date);
       return;
     }
     const today = new Date();


### PR DESCRIPTION
## 📝 작업한 내용

1. dateValidate 함수를 추가하여 localstorage에 저장된 날짜가 내일 날짜보다 이전일 경우 출력 되는 곳에는 내일로 수정하도록 변경 하였습니다.
2. availableAt에 잘못된 값이 들어있는 경우 방어 로직 추가 했습니다.