### PR TITLE
[film/#163] geolocation 사용 불가한 경우의 로직을 수정했습니다.

### DIFF
--- a/src/pages/CreatePostPage/components/FirstStep/index.tsx
+++ b/src/pages/CreatePostPage/components/FirstStep/index.tsx
@@ -12,16 +12,15 @@ const FirstStep = ({ goNextStep, location, handleLocation }: FirstStepProps) => 
   const navigate = useNavigate();
 
   const getGeoLocation = () => {
-    if (!navigator.geolocation) {
-      Toast.info('GPS를 지원하지 않습니다.');
-      return;
-    }
-    navigator.geolocation.getCurrentPosition((position) => {
-      setUserLocation({
-        latitude: position.coords.latitude,
-        longitude: position.coords.longitude,
-      });
-    });
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        setUserLocation({
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+        });
+      },
+      () => Toast.warn('GPS를 지원하지 않습니다.'),
+    );
   };
 
   useEffect(() => {


### PR DESCRIPTION
## 📝 작업한 내용

 geolocation 사용 불가한 경우의 로직을 수정했습니다.

## 📌 리뷰 시 참고 사항

navigation.geolocation 은 무조건 true로 반환되어 if문에 사용 할 수 없었고,
geolocation.getCurrentPosition( 성공시 callback, 실패시 callback) 으로 작성이 가능하여 변경 했습니다.


## 📷 화면 사진

<img width="338" alt="image" src="https://user-images.githubusercontent.com/68111046/146685392-5fd7d2da-0e7e-4311-b71e-3a07dc2c9d90.png">

