### PR TITLE
[film/#180] DateInput에 사용 될 date값을 new Date()가 아닌 KST를 계산하여 설정합니다.

### DIFF
--- a/src/pages/CreatePostPage/components/ThirdStep/index.tsx
+++ b/src/pages/CreatePostPage/components/ThirdStep/index.tsx
@@ -45,10 +45,19 @@ const ThirdStep = ({
   };
 
   const dateValidate = (date: string) => {
-    const today = new Date();
-    const tomorrow = new Date(today.setDate(today.getDate() + 2)).getDate();
+    const tomorrow = getKST(true).getDate();
     const storedDate = new Date(date).getDate();
     return tomorrow > storedDate ? false : true;
+  };
+
+  const getKST = (tomorrow: boolean) => {
+    const curr = new Date();
+    const utc = curr.getTime() + curr.getTimezoneOffset() * 60 * 1000;
+    const KR_TIME_DIFF = 9 * 60 * 60 * 1000;
+    const TOMORROW_TIME_DIFF = 24 * 60 * 60 * 1000;
+    const kr_curr = new Date(utc + KR_TIME_DIFF);
+    const kr_tomorrow = new Date(utc + KR_TIME_DIFF + TOMORROW_TIME_DIFF);
+    return tomorrow ? kr_tomorrow : kr_curr;
   };
 
   useEffect(() => {
@@ -71,9 +80,7 @@ const ThirdStep = ({
       setMinDay(date);
       return;
     }
-    const today = new Date();
-    const tomorrow = new Date(today.setDate(today.getDate() + 2)).toISOString().split('T')[0];
-
+    const tomorrow = getKST(true).toISOString().split('T')[0];
     setMinDay(tomorrow);
     setDate(tomorrow);
   }, []);


### PR DESCRIPTION

## 📝 작업한 내용

DateInput에 사용 될 date값을 new Date()가 아닌 KST를 계산하여 설정합니다.

## 📌 리뷰 시 참고 사항

서버에서 state가 변경되는 시간이 KST 기준 12시라서
현재 날짜를 구할 때 단순 new Date()가 아닌 KST를 구하는 방식으로 변경 하였습니다.


자세한 내용 위키에 적어두었습니다.
[위키 링크](https://github.com/prgrms-web-devcourse/Team_17TOP_Film_FE/wiki/JavaScript%EC%97%90%EC%84%9C-KST,-TOMORROW-%EA%B5%AC%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%95)


