### PR TITLE
[Film/#188] postDetail Page XX일 째 함께 하는중 실제 데이터와 연결되도록 구현

### DIFF
--- a/src/pages/CreatePostPage/components/ThirdStep/index.tsx
+++ b/src/pages/CreatePostPage/components/ThirdStep/index.tsx
@@ -16,6 +16,7 @@ import UploadHeader from '../UploadHeader';
 import SelectedUserList from '../../../../components/organism/SelectedUserList';
 import SearchUser from '../../../../components/organism/SearchUser';
 import { useSelectedUserList } from '../../../../contexts/SelectedUserListProvider';
+import { getKST } from '../../../../utils/functions/getKST';
 
 const ThirdStep = ({
   latitude,
@@ -55,16 +56,6 @@ const ThirdStep = ({
     const tomorrow = getKST(true).getDate();
     const storedDate = new Date(date).getDate();
     return tomorrow > storedDate ? false : true;
-  };
-
-  const getKST = (tomorrow: boolean) => {
-    const curr = new Date();
-    const utc = curr.getTime() + curr.getTimezoneOffset() * 60 * 1000;
-    const KR_TIME_DIFF = 9 * 60 * 60 * 1000;
-    const TOMORROW_TIME_DIFF = 24 * 60 * 60 * 1000;
-    const kr_curr = new Date(utc + KR_TIME_DIFF);
-    const kr_tomorrow = new Date(utc + KR_TIME_DIFF + TOMORROW_TIME_DIFF);
-    return tomorrow ? kr_tomorrow : kr_curr;
   };
 
   useEffect(() => {

--- a/src/pages/PostDetailPage/index.tsx
+++ b/src/pages/PostDetailPage/index.tsx
@@ -21,6 +21,7 @@ import { StaticMap, Marker } from 'react-map-gl';
 import { Pin } from '../../components/organism';
 import ConfirmModal from '../HomePage/Modal';
 import { useUserInfo } from '../../contexts/UserProvider';
+import { getKST } from '../../utils/functions/getKST';
 
 const PostDetailPage = () => {
   const { userInfo } = useUserInfo();
@@ -29,6 +30,7 @@ const PostDetailPage = () => {
   const { postId } = useParams();
   const [postDetail, setPostDetail] = useState<PostDetail | null>(null);
   const [postDeleteModalVisible, setPostDeleteModalVisible] = useState(false);
+  const [togetherDate, setTogetherDate] = useState(0);
   const getPostDetail = async (postId: number) => {
     const { data, error } = await getPostDetailApi(postId);
     console.log(data, error);
@@ -58,6 +60,15 @@ const PostDetailPage = () => {
       clearTimeout(id);
     };
   }, []);
+
+  useEffect(() => {
+    if (!postDetail) {
+      return;
+    }
+    const postCreatedAt = new Date(postDetail.createdAt).getDate();
+    const today = getKST(false).getDate();
+    setTogetherDate(today - postCreatedAt);
+  }, [postDetail]);
 
   return (
     <div>
@@ -131,7 +142,7 @@ const PostDetailPage = () => {
                 </StaticMap>
               </MapWrapper>
             </div>
-            <RelativeDay textType="SmallText">100일째 함께하는중😊</RelativeDay>
+            <RelativeDay textType="SmallText">{togetherDate}일째 함께하는중😊</RelativeDay>
             <AuthoryityList>
               <Avatar.Group overlapPx={8}>
                 {postDetail.authorityImageList.map((user) => (

--- a/src/utils/functions/getKST.ts
+++ b/src/utils/functions/getKST.ts
@@ -1,0 +1,9 @@
+export const getKST = (tomorrow: boolean) => {
+  const curr = new Date();
+  const utc = curr.getTime() + curr.getTimezoneOffset() * 60 * 1000;
+  const KR_TIME_DIFF = 9 * 60 * 60 * 1000;
+  const TOMORROW_TIME_DIFF = 24 * 60 * 60 * 1000;
+  const kr_curr = new Date(utc + KR_TIME_DIFF);
+  const kr_tomorrow = new Date(utc + KR_TIME_DIFF + TOMORROW_TIME_DIFF);
+  return tomorrow ? kr_tomorrow : kr_curr;
+};


### PR DESCRIPTION
## 📝 작업한 내용

1. postDetail Page XX일 째 함께 하는 중 실제 데이터와 연결되도록 구현하였습니다.
2. getKST 함수를 utils/functions에 이동시켰습니다. 

## 📌 리뷰 시 참고 사항

1. getKST(tomorrow : boolean) : KST 기준 오늘 날짜 혹은 내일 날짜를 가져오는 함수 입니다.
2. postDetail이 변경 될 때 값이 존재 한다면 createdAt과 getKST(false)를 비교하여 togetherDate 에 넣어줍니다.


## 📷 화면 사진

![image](https://user-images.githubusercontent.com/68111046/146738963-7a0212ee-86a5-4904-9f8f-df9bf04983f5.png)

