### PR TITLE
[Film/#208] 업로드 페이지 위치정보 사용할 수 없어도 로딩 되도록 수정

### DIFF
--- a/src/components/organism/Toast/components/ToastItem/style.ts
+++ b/src/components/organism/Toast/components/ToastItem/style.ts
@@ -4,7 +4,7 @@ import { MdClose } from 'react-icons/md';
 const Container = styled.div`
   position: relative;
   height: inherit;
-  word-wrap: break-word;
+  word-break: keep-all;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
   box-sizing: border-box;
   opacity: 1;

--- a/src/pages/CreatePostPage/components/FirstStep/index.tsx
+++ b/src/pages/CreatePostPage/components/FirstStep/index.tsx
@@ -8,9 +8,12 @@ import Toast from '../../../../components/organism/Toast';
 import Loader from '../../../../components/organism/Loader';
 
 const FirstStep = ({ goNextStep, location, handleLocation }: FirstStepProps) => {
-  const [userLocation, setUserLocation] = useState(location || null);
+  const [userLocation, setUserLocation] = useState(
+    location || { latitude: 37.492129011067, longitude: 127.03001913095 },
+  );
   const [marker, setMarker] = useState({ latitude: 37, longitude: 126 });
   const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
 
   const getGeoLocation = () => {
     navigator.geolocation.getCurrentPosition(
@@ -19,13 +22,18 @@ const FirstStep = ({ goNextStep, location, handleLocation }: FirstStepProps) => 
           latitude: position.coords.latitude,
           longitude: position.coords.longitude,
         });
+        setIsLoading(false);
       },
-      () => Toast.warn('GPS를 지원하지 않습니다.'),
+      () => {
+        setIsLoading(false);
+        Toast.warn('GPS를 지원하지않아 꿈의 직장 프로그래머스로 이동합니다 😉');
+      },
     );
   };
 
   useEffect(() => {
     if (!location) {
+      setIsLoading(true);
       getGeoLocation();
       return;
     }
@@ -46,23 +54,19 @@ const FirstStep = ({ goNextStep, location, handleLocation }: FirstStepProps) => 
 
   return (
     <>
-      {!userLocation ? <Loader>필름 맡기러 가는중...</Loader> : ''}
+      {isLoading ? <Loader>내 위치 불러오는 중...</Loader> : ''}
       <UploadHeader handleBackBtn={() => navigate(-1)}></UploadHeader>
       <MapHeaderText textType="Heading3">
         필름을 맡길
         <br />
         위치를 선택 해주세요
       </MapHeaderText>
-      {userLocation ? (
-        <Map
-          latitude={userLocation.latitude}
-          longitude={userLocation.longitude}
-          marker={marker}
-          onChangeMarker={handleMarker}
-        />
-      ) : (
-        ''
-      )}
+      <Map
+        latitude={userLocation.latitude}
+        longitude={userLocation.longitude}
+        marker={marker}
+        onChangeMarker={handleMarker}
+      />
       <NextStepButton buttonType="PrimaryBtn" onClick={saveLocation}>
         <NextStepText textType="Paragraph1">여기에 만들래요</NextStepText>
       </NextStepButton>


### PR DESCRIPTION
## 📝 작업한 내용

1. 업로드 페이지 위치 정보 사용할 수 없으면 로더에서 막아주던 부분을 사용할 수 없어도 로딩 되도록 수정했습니다.
2. Toast Container word-wrap -> word-break: keep-all로 수정 했습니다.

## 📷 화면 사진

![image](https://user-images.githubusercontent.com/68111046/146784792-a9022376-5465-49ad-b92d-02e0c15266ee.png)


