### PR TITLE
[Film/#238] Text 컴포넌트 리팩토링

### DIFF
--- a/src/components/atoms/Header/style.ts
+++ b/src/components/atoms/Header/style.ts
@@ -9,7 +9,7 @@ const Wrapper = styled.div<{ bgColor?: string }>`
   display: flex;
   justify-content: center;
   align-items: center;
-  box-shadow: ${({ theme }) => theme.colors.shadow};
+  box-shadow: ${({ theme }) => theme.shadows.shadow1};
   background-color: ${({ bgColor }) => bgColor};
   box-sizing: border-box;
   z-index: 10;

--- a/src/components/organism/GlobalNavigation/style.ts
+++ b/src/components/organism/GlobalNavigation/style.ts
@@ -14,7 +14,7 @@ const Elem = styled.button`
 const CustomNavigation = styled(Navigation)`
   position: fixed;
   bottom: 0;
-  box-shadow: ${({ theme }) => theme.colors.shadow};
+  box-shadow: ${({ theme }) => theme.shadows.shadow1};
   z-index: 10;
 `;
 export { Elem, CustomNavigation };

--- a/src/components/refactor/atoms/Text/index.tsx
+++ b/src/components/refactor/atoms/Text/index.tsx
@@ -1,0 +1,11 @@
+import { StyledText } from './style';
+import { TextProps } from './types';
+
+const Text = ({ textType, textColor, children, ...props }: TextProps) => {
+  return (
+    <StyledText textType={textType} textColor={textColor} {...props}>
+      {children}
+    </StyledText>
+  );
+};
+export default Text;

--- a/src/components/refactor/atoms/Text/style.ts
+++ b/src/components/refactor/atoms/Text/style.ts
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+import { TextProps } from './types';
+
+const StyledText = styled.div<Pick<TextProps, 'textType' | 'textColor'>>`
+  ${({ theme, textType }) => theme.fonts[textType]}
+  color:${({ theme, textColor }) => (textColor ? theme.colors[textColor] : '')}
+`;
+
+export { StyledText };

--- a/src/components/refactor/atoms/Text/types.ts
+++ b/src/components/refactor/atoms/Text/types.ts
@@ -1,0 +1,30 @@
+import { ReactNode } from 'react';
+
+export interface TextProps {
+  children: ReactNode;
+  textType: TextType;
+  textColor?: TextColor;
+}
+
+type TextType =
+  | 'Heading1'
+  | 'Heading2'
+  | 'Heading3'
+  | 'Heading4'
+  | 'Paragraph1'
+  | 'Paragraph2'
+  | 'smallText';
+
+type TextColor =
+  | 'gray50'
+  | 'gray100'
+  | 'gray200'
+  | 'gray300'
+  | 'gray400'
+  | 'gray500'
+  | 'gray600'
+  | 'gray700'
+  | 'gray800'
+  | 'gray900'
+  | 'primary'
+  | 'red900';

--- a/src/components/refactor/atoms/Text/types.ts
+++ b/src/components/refactor/atoms/Text/types.ts
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { theme } from '../../../../styles/theme';
 
 export interface TextProps {
   children: ReactNode;
@@ -6,25 +7,6 @@ export interface TextProps {
   textColor?: TextColor;
 }
 
-type TextType =
-  | 'Heading1'
-  | 'Heading2'
-  | 'Heading3'
-  | 'Heading4'
-  | 'Paragraph1'
-  | 'Paragraph2'
-  | 'smallText';
+type TextType = keyof typeof theme.fonts;
 
-type TextColor =
-  | 'gray50'
-  | 'gray100'
-  | 'gray200'
-  | 'gray300'
-  | 'gray400'
-  | 'gray500'
-  | 'gray600'
-  | 'gray700'
-  | 'gray800'
-  | 'gray900'
-  | 'primary'
-  | 'red900';
+type TextColor = keyof typeof theme.colors;

--- a/src/pages/MyPage/components/Film/style.tsx
+++ b/src/pages/MyPage/components/Film/style.tsx
@@ -4,7 +4,7 @@ import { Button, Text } from '../../../../components/atoms';
 const Wrapper = styled.div`
   margin: ${({ theme: { gaps } }) => `0 ${gaps.default_margin} 32px`};
   padding: ${({ theme: { gaps } }) => gaps.default_margin};
-  box-shadow: ${({ theme: { colors } }) => colors.shadow};
+  box-shadow: ${({ theme: { shadows } }) => shadows.shadow1};
   border-radius: 4px;
   position: relative;
 `;

--- a/src/pages/SignUpPage/style.ts
+++ b/src/pages/SignUpPage/style.ts
@@ -7,7 +7,7 @@ const Header = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  box-shadow: ${({ theme: { colors } }) => colors.shadow};
+  box-shadow: ${({ theme: { shadows } }) => shadows.shadow1};
 `;
 const BackBtn = styled.button`
   position: absolute;

--- a/src/stories/components/Text.stories.tsx
+++ b/src/stories/components/Text.stories.tsx
@@ -1,0 +1,41 @@
+import Text from '../../components/refactor/atoms/Text';
+
+export default {
+  title: 'Example/Text',
+  component: Text,
+  argTypes: {
+    textType: {
+      options: [
+        'Heading1',
+        'Heading2',
+        'Heading3',
+        'Heading4',
+        'Paragraph1',
+        'Paragraph2',
+        'smallText',
+      ],
+      control: { type: 'radio' },
+    },
+    textColor: {
+      options: [
+        'gray50',
+        'gray100',
+        'gray200',
+        'gray300',
+        'gray400',
+        'gray500',
+        'gray600',
+        'gray700',
+        'gray800',
+        'gray900',
+        'primary',
+        'red900',
+      ],
+      control: { type: 'radio' },
+    },
+  },
+};
+
+export const Default = (args: any) => {
+  return <Text {...args}>예시용 텍스트 입니다.</Text>;
+};

--- a/src/stories/components/Text.stories.tsx
+++ b/src/stories/components/Text.stories.tsx
@@ -14,7 +14,7 @@ export default {
         'Paragraph2',
         'smallText',
       ],
-      control: { type: 'radio' },
+      control: { type: 'select' },
     },
     textColor: {
       options: [
@@ -31,7 +31,7 @@ export default {
         'primary',
         'red900',
       ],
-      control: { type: 'radio' },
+      control: { type: 'select' },
     },
   },
 };

--- a/src/stories/components/Text.stories.tsx
+++ b/src/stories/components/Text.stories.tsx
@@ -39,3 +39,13 @@ export default {
 export const Default = (args: any) => {
   return <Text {...args}>예시용 텍스트 입니다.</Text>;
 };
+export const TextType = (args: any) => {
+  return <Text {...args}>예시용 텍스트 입니다.</Text>;
+};
+export const TextColor = (args: any) => {
+  return (
+    <Text textType="Heading1" textColor="red900" {...args}>
+      예시용 텍스트 입니다.
+    </Text>
+  );
+};

--- a/src/styles/theme/colors.ts
+++ b/src/styles/theme/colors.ts
@@ -10,7 +10,6 @@ const colors = {
   gray800: '#363A3C',
   gray900: '#292A2B',
   primary: '#00CF9D',
-  shadow: `0px 4px 20px rgba(0, 0, 0, 0.1)`,
   red900: '#F5544E',
 };
 export default colors;

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -1,7 +1,7 @@
 import fonts from './fonts';
 import colors from './colors';
 import gaps from './gaps';
-
+import shadows from './shadows';
 type ThemeType = typeof theme;
 declare module '@emotion/react' {
   export interface Theme extends ThemeType {}
@@ -11,4 +11,5 @@ export const theme = {
   fonts,
   colors,
   gaps,
+  shadows,
 } as const;

--- a/src/styles/theme/shadows.ts
+++ b/src/styles/theme/shadows.ts
@@ -1,0 +1,5 @@
+const shadows = {
+  shadow1: `0px 4px 20px rgba(0, 0, 0, 0.1)`,
+};
+
+export default shadows;


### PR DESCRIPTION
## 📝 작업한 내용

1. index에서 switch문 사용하지 않도록 변경 하였습니다.
2. textColor를 theme에 지정한 색상으로 사용 가능하도록 작성 하였습니다. 
  기존 Text 컴포넌트는 단순 색상 변경도 styled를 사용하여 색상을 지정했던 것이 생각나서 추가했습니다.
  textColor는  `optional`입니다.

## 📌 리뷰 시 참고 사항

style.ts에서 ${({ theme, textType }) => theme.fonts[textType]}
이렇게 사용하다보니 혹시나 theme.fonts에 속성등이 추가, 변경 되면 type도 변경 해줘야하고 추적이 어려울 수도 있으려나 생각이 드는데, 더 나은 방법이 있을까요?

## 😉 리뷰 후 수정 사항
 1. keyof typeof를 사용하여 동적으로 받아올 수 있도록 변경 하였습니다.
 2. storybook에서 control를 select로 변경 하였습니다.
 3. theme.colors에서 shadow를 shadows 파일로 분리, theme.colors.shadow 사용되던 코드를 수정 하였습니다.
 
## 📷 화면 사진
<img width="763" alt="text스토리북" src="https://user-images.githubusercontent.com/68111046/149912285-586b945f-14f7-4720-811b-6321f0ba6dd7.png">



