### PR TITLE
[Film/#244] Upload 컴포넌트 리팩토링

### DIFF
--- a/src/components/atoms/Upload/index.tsx
+++ b/src/components/atoms/Upload/index.tsx
@@ -6,7 +6,7 @@ const Upload = ({
   children,
   name,
   accept,
-  droppable,
+  droppable = true,
   value,
   fileDelete,
   onChange,

--- a/src/components/atoms/Upload/types.ts
+++ b/src/components/atoms/Upload/types.ts
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 
 export interface UploadProps {
-  onChange(file: File): void;
+  onChange(file: File | null): void;
   children?: ReactNode;
   name?: string;
   accept?: string;

--- a/src/components/atoms/Upload/types.ts
+++ b/src/components/atoms/Upload/types.ts
@@ -6,6 +6,6 @@ export interface UploadProps {
   name?: string;
   accept?: string;
   value?: File;
-  droppable: boolean;
+  droppable?: boolean;
   fileDelete?: boolean;
 }

--- a/src/components/refactor/atoms/ImageUpload/constants.ts
+++ b/src/components/refactor/atoms/ImageUpload/constants.ts
@@ -1,0 +1,8 @@
+export const ACCEPTED_IMAGE_FILE_FORMAT = {
+  all: 'image/*',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  bmp: 'image/bmp',
+  gif: 'image/gif',
+  tiff: 'image/tiff',
+};

--- a/src/components/refactor/atoms/ImageUpload/index.tsx
+++ b/src/components/refactor/atoms/ImageUpload/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useMemo, useCallback } from 'react';
+import { useRef, useMemo, useCallback, useEffect } from 'react';
 import { Upload } from '../../../atoms';
 import Toast from '../../../organism/Toast';
 import { ACCEPTED_IMAGE_FILE_FORMAT } from './constants';
@@ -15,7 +15,7 @@ const ImageUpload = ({
   ...props
 }: ImageUploadProps) => {
   const acceptedFileFormatList = useRef<string[]>([]);
-  useMemo(() => {
+  useEffect(() => {
     for (const item of accept) {
       if (item === 'all') {
         acceptedFileFormatList.current = [ACCEPTED_IMAGE_FILE_FORMAT.all];

--- a/src/components/refactor/atoms/ImageUpload/index.tsx
+++ b/src/components/refactor/atoms/ImageUpload/index.tsx
@@ -41,7 +41,11 @@ const ImageUpload = ({
         acceptedFileFormatList.current[0] !== ACCEPTED_IMAGE_FILE_FORMAT.all &&
         !acceptedFileFormatList.current.includes(type)
       ) {
-        Toast.warn(`${acceptedFileFormatList.current.join(', ')} 확장자만 업로드 가능합니다.`);
+        Toast.warn(
+          `${acceptedFileFormatList.current
+            .map((item) => item.replace('image/', '.'))
+            .join(', ')} 확장자만 업로드 가능합니다.`,
+        );
         onChange(null);
         return;
       }

--- a/src/components/refactor/atoms/ImageUpload/index.tsx
+++ b/src/components/refactor/atoms/ImageUpload/index.tsx
@@ -1,0 +1,67 @@
+import { useRef, useMemo, useCallback } from 'react';
+import { Upload } from '../../../atoms';
+import Toast from '../../../organism/Toast';
+import { ACCEPTED_IMAGE_FILE_FORMAT } from './constants';
+import { ImageUploadProps } from './type';
+
+const ImageUpload = ({
+  children,
+  name,
+  accept,
+  droppable,
+  value,
+  fileDelete,
+  onChange,
+  ...props
+}: ImageUploadProps) => {
+  const acceptedFileFormatList = useRef<string[]>([]);
+  useMemo(() => {
+    for (const item of accept) {
+      if (item === 'all') {
+        acceptedFileFormatList.current = [ACCEPTED_IMAGE_FILE_FORMAT.all];
+        return;
+      }
+      acceptedFileFormatList.current.push(ACCEPTED_IMAGE_FILE_FORMAT[item]);
+    }
+  }, [accept]);
+
+  const handleFileChange = useCallback(
+    (file: File) => {
+      if (!file) return;
+      const { type } = file;
+      const mainType = type.split('/')[0];
+
+      if (mainType !== 'image') {
+        Toast.warn('이미지 파일만 업로드 가능합니다.');
+        onChange(null);
+        return;
+      }
+
+      if (
+        acceptedFileFormatList.current[0] !== ACCEPTED_IMAGE_FILE_FORMAT.all &&
+        !acceptedFileFormatList.current.includes(type)
+      ) {
+        Toast.warn(`${acceptedFileFormatList.current.join(', ')} 확장자만 업로드 가능합니다.`);
+        onChange(null);
+        return;
+      }
+      onChange(file);
+    },
+    [onChange, acceptedFileFormatList.current],
+  );
+
+  return (
+    <Upload
+      name={name}
+      accept={acceptedFileFormatList.current.join(', ')}
+      droppable={droppable}
+      value={value}
+      fileDelete={fileDelete}
+      onChange={handleFileChange}
+      {...props}
+    >
+      {children}
+    </Upload>
+  );
+};
+export default ImageUpload;

--- a/src/components/refactor/atoms/ImageUpload/index.tsx
+++ b/src/components/refactor/atoms/ImageUpload/index.tsx
@@ -15,6 +15,7 @@ const ImageUpload = ({
   ...props
 }: ImageUploadProps) => {
   const acceptedFileFormatList = useRef<string[]>([]);
+  const acceptedFileFormatMessage = useRef('');
   useEffect(() => {
     for (const item of accept) {
       if (item === 'all') {
@@ -24,6 +25,11 @@ const ImageUpload = ({
       acceptedFileFormatList.current.push(ACCEPTED_IMAGE_FILE_FORMAT[item]);
     }
   }, [accept]);
+  useEffect(() => {
+    acceptedFileFormatMessage.current = `${acceptedFileFormatList.current
+      .map((item) => item.replace('image/', '.'))
+      .join(', ')} 확장자만 업로드 가능합니다.`;
+  }, [acceptedFileFormatList.current]);
 
   const handleFileChange = useCallback(
     (file: File) => {
@@ -41,11 +47,7 @@ const ImageUpload = ({
         acceptedFileFormatList.current[0] !== ACCEPTED_IMAGE_FILE_FORMAT.all &&
         !acceptedFileFormatList.current.includes(type)
       ) {
-        Toast.warn(
-          `${acceptedFileFormatList.current
-            .map((item) => item.replace('image/', '.'))
-            .join(', ')} 확장자만 업로드 가능합니다.`,
-        );
+        Toast.warn(acceptedFileFormatMessage.current);
         onChange(null);
         return;
       }

--- a/src/components/refactor/atoms/ImageUpload/type.ts
+++ b/src/components/refactor/atoms/ImageUpload/type.ts
@@ -1,0 +1,7 @@
+import { UploadProps } from '../../../atoms/Upload/types';
+import { ACCEPTED_IMAGE_FILE_FORMAT } from './constants';
+
+export interface ImageUploadProps extends Omit<UploadProps, 'accept'> {
+  accept: acceptedImageFileFormat[];
+}
+export type acceptedImageFileFormat = keyof typeof ACCEPTED_IMAGE_FILE_FORMAT;

--- a/src/stories/components/ImageUpload.stories.tsx
+++ b/src/stories/components/ImageUpload.stories.tsx
@@ -23,7 +23,7 @@ export default {
   },
 };
 
-export const Default = (args: any) => {
+const ImageUploadEx = ({ ...props }) => {
   const [imageURL, setImageURL] = useState('');
   const [file, setFile] = useState<File>();
 
@@ -60,10 +60,18 @@ export const Default = (args: any) => {
       onChange={handleSetImageFile}
       imageURL={imageURL}
       fileDelete={file ? false : true}
-      {...args}
+      {...props}
     >
       <ImageUploadIcon imageURL={imageURL}>+</ImageUploadIcon>
       {imageURL ? <PreviewImg src={imageURL} /> : ''}
     </StyledImageUpload>
   );
+};
+
+export const AllType = (args: any) => {
+  return <ImageUploadEx {...args}></ImageUploadEx>;
+};
+
+export const JpegOnly = (args: any) => {
+  return <ImageUploadEx accept={['jpeg']} {...args}></ImageUploadEx>;
 };

--- a/src/stories/components/ImageUpload.stories.tsx
+++ b/src/stories/components/ImageUpload.stories.tsx
@@ -1,0 +1,69 @@
+import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
+import ImageUpload from '../../components/refactor/atoms/ImageUpload';
+import { ImageUploadIcon, PreviewImg } from '../../pages/CreatePostPage/style';
+
+const StyledImageUpload = styled(ImageUpload)<{ imageURL: string }>`
+  border-radius: 4px;
+  position: relative;
+  border: ${({ imageURL }) => (imageURL ? 'none' : '1px solid')};
+  width: 100%;
+  height: ${({ imageURL }) => (imageURL ? 'auto' : '299px')};
+  box-sizing: border-box;
+`;
+
+export default {
+  title: 'Example/ImageUpload',
+  component: StyledImageUpload,
+  argTypes: {
+    droppable: {
+      type: { name: 'boolean' },
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export const Default = (args: any) => {
+  const [imageURL, setImageURL] = useState('');
+  const [file, setFile] = useState<File>();
+
+  const handleSetImageFile = (file: File) => {
+    if (!file) {
+      setImageURL('');
+      setFile(undefined);
+      return;
+    }
+    setFile(file);
+  };
+
+  const fileToDataURL = (file: File) => {
+    const reader = new FileReader();
+
+    if (file) {
+      reader.readAsDataURL(file);
+      reader.onload = (e) => {
+        setImageURL(e.target?.result as string);
+      };
+    } else {
+      setImageURL('');
+    }
+  };
+
+  useEffect(() => {
+    if (file) {
+      fileToDataURL(file);
+    }
+  }, [file]);
+  return (
+    <StyledImageUpload
+      accept={['all']}
+      onChange={handleSetImageFile}
+      imageURL={imageURL}
+      fileDelete={file ? false : true}
+      {...args}
+    >
+      <ImageUploadIcon imageURL={imageURL}>+</ImageUploadIcon>
+      {imageURL ? <PreviewImg src={imageURL} /> : ''}
+    </StyledImageUpload>
+  );
+};


### PR DESCRIPTION
## 📝 작업한 내용

지정한 확장자를 가진 파일만 업로드 가능 하도록 Upload 컴포넌트를 리팩토링 하려 하였으나, 모든 파일 확장자를 고려하기는 어려울 것 같다는 판단 하에 팀원과 상의 후 ImageUpload 컴포넌트를 따로 제작 하기로 하였습니다.

1. 미리 지정 해둔 accept 값을 입력하면 거기에 해당하는 파일들만 받을 수 있도록 구현 하였습니다. 
    `accept={ ['all'] }` 혹은  `accept={['jpeg','bmp']}`등의 배열에 확장자명을 하나씩 입력하는 형태로 사용 가능합니다.  해당 값은 미리 지정 된 값만 입력 가능합니다.

2. Upload 컴포넌트에서 droppable 옵션을 필수에서 선택 사항으로 번경하고, 기본 값을 true로 설정 하였습니다.

## 📌 리뷰 시 참고 사항

1. all말고도 몇가지 확장자를 묶어서 하나로 사용 할 수 있도록 하는 것이 좋을까요?
2. storybook에서 accept 속성을 control에서 사용 하는 방법을 찾지 못하여 AllType , JpegOnly 등으로 스토리를 작성 하였으나 추후에 방법을 찾으면 수정 하겠습니다.. 

## 📷 화면 사진

![Iup1](https://user-images.githubusercontent.com/68111046/151320762-e39d5008-1316-414f-9e4a-e1fec838ecd6.gif)
![Iup2](https://user-images.githubusercontent.com/68111046/151320772-66a3670d-7cef-40aa-86be-50507d2494f7.gif)


