### PR TITLE
[Film/#248] Modal 컴포넌트 리팩토링

### DIFF
--- a/src/components/refactor/atoms/Modal/index.tsx
+++ b/src/components/refactor/atoms/Modal/index.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useEffect, useMemo } from 'react';
 import ReactDOM from 'react-dom';
-import { BackkgroundDim, Wrapper } from './style';
+import { BackgroundDim, Wrapper } from './style';
 interface Props {
   children: ReactNode;
   onClose?: () => void;
@@ -16,9 +16,9 @@ const Modal = ({ children, onClose }: Props) => {
   }, []);
 
   return ReactDOM.createPortal(
-    <BackkgroundDim onClick={onClose}>
+    <BackgroundDim onClick={onClose}>
       <Wrapper>{children}</Wrapper>
-    </BackkgroundDim>,
+    </BackgroundDim>,
     modalElement,
   );
 };

--- a/src/components/refactor/atoms/Modal/index.tsx
+++ b/src/components/refactor/atoms/Modal/index.tsx
@@ -1,11 +1,13 @@
-import { ReactNode, useEffect, useMemo } from 'react';
+import { MutableRefObject, ReactNode, useEffect, useMemo } from 'react';
 import ReactDOM from 'react-dom';
 import { BackgroundDim, Wrapper } from './style';
+import useClickOutSide from './useClickOutSide';
 interface Props {
   children: ReactNode;
-  onClose?: () => void;
+  dimClose?: () => void;
 }
-const Modal = ({ children, onClose }: Props) => {
+const Modal = ({ children, dimClose }: Props) => {
+  const ref = useClickOutSide(() => dimClose && dimClose());
   const modalElement = useMemo(() => document.createElement('div'), []);
 
   useEffect(() => {
@@ -16,8 +18,8 @@ const Modal = ({ children, onClose }: Props) => {
   }, []);
 
   return ReactDOM.createPortal(
-    <BackgroundDim onClick={onClose}>
-      <Wrapper>{children}</Wrapper>
+    <BackgroundDim>
+      <Wrapper ref={ref as MutableRefObject<HTMLDivElement>}>{children}</Wrapper>
     </BackgroundDim>,
     modalElement,
   );

--- a/src/components/refactor/atoms/Modal/index.tsx
+++ b/src/components/refactor/atoms/Modal/index.tsx
@@ -1,0 +1,26 @@
+import { ReactNode, useEffect, useMemo } from 'react';
+import ReactDOM from 'react-dom';
+import { BackkgroundDim, Wrapper } from './style';
+interface Props {
+  children: ReactNode;
+  onClose?: () => void;
+}
+const Modal = ({ children, onClose }: Props) => {
+  const modalElement = useMemo(() => document.createElement('div'), []);
+
+  useEffect(() => {
+    document.body.appendChild(modalElement);
+    return () => {
+      document.body.removeChild(modalElement);
+    };
+  }, []);
+
+  return ReactDOM.createPortal(
+    <BackkgroundDim onClick={onClose}>
+      <Wrapper>{children}</Wrapper>
+    </BackkgroundDim>,
+    modalElement,
+  );
+};
+
+export default Modal;

--- a/src/components/refactor/atoms/Modal/index.tsx
+++ b/src/components/refactor/atoms/Modal/index.tsx
@@ -12,8 +12,10 @@ const Modal = ({ children, dimClose }: Props) => {
 
   useEffect(() => {
     document.body.appendChild(modalElement);
+    document.body.style.overflow = 'hidden';
     return () => {
       document.body.removeChild(modalElement);
+      document.body.style.overflow = 'auto';
     };
   }, []);
 

--- a/src/components/refactor/atoms/Modal/style.ts
+++ b/src/components/refactor/atoms/Modal/style.ts
@@ -16,7 +16,7 @@ const Wrapper = styled.div`
   left: 50%;
   transform: translate(-50%, -50%);
   max-height: 80vh;
-  overflow: scroll;
+  overflow-y: auto;
 `;
 
 export { BackgroundDim, Wrapper };

--- a/src/components/refactor/atoms/Modal/style.ts
+++ b/src/components/refactor/atoms/Modal/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-const BackkgroundDim = styled.div`
+const BackgroundDim = styled.div`
   position: fixed;
   top: 0;
   left: 0;
@@ -12,11 +12,11 @@ const BackkgroundDim = styled.div`
 
 const Wrapper = styled.div`
   position: fixed;
-  top 50%;
+  top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
   max-height: 80vh;
   overflow: scroll;
 `;
 
-export { BackkgroundDim, Wrapper };
+export { BackgroundDim, Wrapper };

--- a/src/components/refactor/atoms/Modal/style.ts
+++ b/src/components/refactor/atoms/Modal/style.ts
@@ -1,0 +1,22 @@
+import styled from '@emotion/styled';
+
+const BackkgroundDim = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+`;
+
+const Wrapper = styled.div`
+  position: fixed;
+  top 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-height: 80vh;
+  overflow: scroll;
+`;
+
+export { BackkgroundDim, Wrapper };

--- a/src/components/refactor/atoms/Modal/useClickOutSide.ts
+++ b/src/components/refactor/atoms/Modal/useClickOutSide.ts
@@ -1,0 +1,34 @@
+import { RefObject, useEffect, useRef } from 'react';
+
+const eventTypes = ['mouseup', 'touchend'];
+
+const useClickOutSide = (handler: () => void): RefObject<HTMLElement> => {
+  const ref = useRef<HTMLElement>(null);
+  const saveHandler = useRef(handler);
+
+  useEffect(() => {
+    saveHandler.current = handler;
+  }, [handler]);
+
+  useEffect(() => {
+    const targetElement = ref.current;
+    if (!targetElement) return;
+
+    const handleClickOutside = (e: Event) => {
+      !targetElement.contains(e.target as HTMLElement) && saveHandler.current();
+    };
+
+    for (const eventType of eventTypes) {
+      document.addEventListener(eventType, handleClickOutside);
+    }
+    return () => {
+      for (const eventType of eventTypes) {
+        document.removeEventListener(eventType, handleClickOutside);
+      }
+    };
+  }, [ref]);
+
+  return ref;
+};
+
+export default useClickOutSide;

--- a/src/components/refactor/atoms/Text/style.ts
+++ b/src/components/refactor/atoms/Text/style.ts
@@ -3,7 +3,7 @@ import { TextProps } from './types';
 
 const StyledText = styled.div<Pick<TextProps, 'textType' | 'textColor'>>`
   ${({ theme, textType }) => theme.fonts[textType]}
-  color:${({ theme, textColor }) => (textColor ? theme.colors[textColor] : '')}
+  color: ${({ theme, textColor }) => (textColor ? theme.colors[textColor] : '')};
 `;
 
 export { StyledText };

--- a/src/components/refactor/atoms/index.ts
+++ b/src/components/refactor/atoms/index.ts
@@ -2,3 +2,4 @@ export { default as Button } from './Button';
 export { default as Input } from './Input';
 export { default as Img } from './Img';
 export { default as Icon } from './Icon';
+export { default as Modal } from './Modal';

--- a/src/components/refactor/atoms/index.ts
+++ b/src/components/refactor/atoms/index.ts
@@ -1,3 +1,4 @@
+export { default as Text } from './Text';
 export { default as Button } from './Button';
 export { default as Input } from './Input';
 export { default as Img } from './Img';

--- a/src/components/refactor/organism/ConfirmModal/index.tsx
+++ b/src/components/refactor/organism/ConfirmModal/index.tsx
@@ -1,0 +1,38 @@
+import { Modal } from '@refactors/atoms';
+import { ModalWrapper, ModalText, ButtonGroup, ModalButton } from './style';
+
+interface Props {
+  modalText: string;
+  primaryBtnText: string;
+  secondaryBtnText: string;
+  dimClose?: () => void;
+  primaryBtnEvent: () => void;
+  secondaryBtnEvent: () => void;
+}
+
+const ConfirmModal = ({
+  modalText,
+  primaryBtnText,
+  secondaryBtnText,
+  dimClose,
+  primaryBtnEvent,
+  secondaryBtnEvent,
+}: Props) => {
+  return (
+    <Modal dimClose={dimClose}>
+      <ModalWrapper>
+        <ModalText textType="Heading4">{modalText}</ModalText>
+        <ButtonGroup>
+          <ModalButton btnStyle={'secondary'} size={'full'} onClick={secondaryBtnEvent}>
+            {secondaryBtnText}
+          </ModalButton>
+          <ModalButton btnStyle={'primary'} size={'full'} onClick={primaryBtnEvent}>
+            {primaryBtnText}
+          </ModalButton>
+        </ButtonGroup>
+      </ModalWrapper>
+    </Modal>
+  );
+};
+
+export default ConfirmModal;

--- a/src/components/refactor/organism/ConfirmModal/index.tsx
+++ b/src/components/refactor/organism/ConfirmModal/index.tsx
@@ -5,7 +5,6 @@ interface Props {
   modalText: string;
   primaryBtnText: string;
   secondaryBtnText: string;
-  dimClose?: () => void;
   primaryBtnEvent: () => void;
   secondaryBtnEvent: () => void;
 }
@@ -14,12 +13,11 @@ const ConfirmModal = ({
   modalText,
   primaryBtnText,
   secondaryBtnText,
-  dimClose,
   primaryBtnEvent,
   secondaryBtnEvent,
 }: Props) => {
   return (
-    <Modal dimClose={dimClose}>
+    <Modal>
       <ModalWrapper>
         <ModalText textType="Heading4">{modalText}</ModalText>
         <ButtonGroup>

--- a/src/components/refactor/organism/ConfirmModal/style.ts
+++ b/src/components/refactor/organism/ConfirmModal/style.ts
@@ -2,8 +2,11 @@ import styled from '@emotion/styled';
 import { Text, Button } from '@refactors/atoms';
 
 const ModalWrapper = styled.div`
+  width: 100%;
   min-width: 300px;
+  max-width: 480px;
   padding: ${({ theme }) => theme.gaps.gap2};
+  box-sizing: border-box;
   background: #fff;
   border-radius: 4px;
   text-align: center;

--- a/src/components/refactor/organism/ConfirmModal/style.ts
+++ b/src/components/refactor/organism/ConfirmModal/style.ts
@@ -1,0 +1,25 @@
+import styled from '@emotion/styled';
+import { Text, Button } from '@refactors/atoms';
+
+const ModalWrapper = styled.div`
+  min-width: 300px;
+  padding: ${({ theme }) => theme.gaps.gap2};
+  background: #fff;
+  border-radius: 4px;
+  text-align: center;
+`;
+const ModalText = styled(Text)`
+  margin-top: ${({ theme }) => theme.gaps.gap2};
+  line-height: 1.4;
+  word-break: keep-all;
+`;
+const ButtonGroup = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.gaps.gap1};
+  margin-top: ${({ theme }) => theme.gaps.gap4};
+`;
+const ModalButton = styled(Button)`
+  justify-content: center;
+`;
+
+export { ModalWrapper, ModalText, ButtonGroup, ModalButton };

--- a/src/components/refactor/organism/index.ts
+++ b/src/components/refactor/organism/index.ts
@@ -1,2 +1,3 @@
 export { default as BottomNavigation } from './BottomNavigation';
 export { default as BNItem } from './BottomNavigation/BNItem';
+export { default as ConfirmModal } from './ConfirmModal';

--- a/src/stories/components/ConfirmModal.stories.tsx
+++ b/src/stories/components/ConfirmModal.stories.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { ConfirmModal } from '@refactors/organism';
+import { Button } from '@refactors/atoms';
+
+export default {
+  title: 'Example/ConfirmModal',
+  component: ConfirmModal,
+  argTypes: {
+    modalText: {
+      type: { name: 'string', required: true },
+      control: { type: 'text' },
+    },
+    primaryBtnText: {
+      type: { name: 'string', required: true },
+      control: { type: 'text' },
+    },
+    secondaryBtnText: {
+      type: { name: 'string', required: true },
+      control: { type: 'text' },
+    },
+    primaryBtnEvent: {
+      action: '확인 클릭',
+    },
+    secondaryBtnEvent: {
+      action: '취소 클릭',
+    },
+  },
+};
+
+export const Default = (args: any) => {
+  const [modalVisible, setModalVisible] = useState(false);
+  return (
+    <div>
+      <Button btnStyle="primary" size="medium" onClick={() => setModalVisible(true)}>
+        ConfirmModal 열기
+      </Button>
+      {modalVisible && (
+        <ConfirmModal
+          modalText={`모달 텍스트를 넣어주세요`}
+          primaryBtnText={`확인`}
+          secondaryBtnText={`취소`}
+          dimClose={() => setModalVisible(false)}
+          primaryBtnEvent={() => {
+            console.log('확인 클릭');
+          }}
+          secondaryBtnEvent={() => {
+            console.log('취소 클릭');
+          }}
+          {...args}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/stories/components/ConfirmModal.stories.tsx
+++ b/src/stories/components/ConfirmModal.stories.tsx
@@ -39,11 +39,11 @@ export const Default = (args: any) => {
           modalText={`모달 텍스트를 넣어주세요`}
           primaryBtnText={`확인`}
           secondaryBtnText={`취소`}
-          dimClose={() => setModalVisible(false)}
           primaryBtnEvent={() => {
             console.log('확인 클릭');
           }}
           secondaryBtnEvent={() => {
+            setModalVisible(false);
             console.log('취소 클릭');
           }}
           {...args}

--- a/src/stories/components/Modal.stories.tsx
+++ b/src/stories/components/Modal.stories.tsx
@@ -16,7 +16,7 @@ export const Default = (args: any) => {
         모달 열기
       </Button>
       {modalVisible && (
-        <Modal {...args}>
+        <Modal dimClose={() => setModalVisible(false)} {...args}>
           <ModalInner>
             <ModalText textType="Heading4">모달 텍스트를 넣어주세요</ModalText>
             <ButtonGroup>

--- a/src/stories/components/Modal.stories.tsx
+++ b/src/stories/components/Modal.stories.tsx
@@ -1,44 +1,55 @@
 import styled from '@emotion/styled';
-import React, { useState } from 'react';
-import { Button, Modal } from '../../components/atoms';
+import { Text, Button, Modal } from '@refactors/atoms';
+import { useState } from 'react';
 
 export default {
   title: 'Example/Modal',
   component: Modal,
+  argTypes: {},
 };
 
 export const Default = (args: any) => {
   const [modalVisible, setModalVisible] = useState(false);
   return (
-    <>
-      <Button buttonType="PrimaryBtn" onClick={() => setModalVisible(true)}>
+    <div style={{ height: '10000px' }}>
+      <Button btnStyle="primary" size="medium" onClick={() => setModalVisible(true)}>
         모달 열기
       </Button>
-      <Modal visible={modalVisible} onClose={() => setModalVisible(false)}>
-        <ModalInner>
-          <Text>오늘 열 수 있는 캡슐이 있어요</Text>
-          <Footer>
-            <Button buttonType="SecondaryBtn" onClick={() => setModalVisible(false)}>
-              나중에 볼래요
-            </Button>
-            <Button buttonType="PrimaryBtn" onClick={() => setModalVisible(false)}>
-              보러 갈래요!
-            </Button>
-          </Footer>
-        </ModalInner>
-      </Modal>
-    </>
+      {modalVisible && (
+        <Modal {...args}>
+          <ModalInner>
+            <ModalText textType="Heading4">모달 텍스트를 넣어주세요</ModalText>
+            <ButtonGroup>
+              <ModalButton btnStyle="secondary" size="full" onClick={() => setModalVisible(false)}>
+                닫기
+              </ModalButton>
+            </ButtonGroup>
+          </ModalInner>
+        </Modal>
+      )}
+    </div>
   );
 };
-const ModalInner = styled.div`
-  width: 300px;
-`;
 
-const Text = styled.h1`
-  margin: 10px 0;
+const ModalInner = styled.div`
+  min-width: 300px;
+  background: #fff;
+  padding: ${({ theme }) => theme.gaps.gap2};
+  border-radius: 4px;
   text-align: center;
 `;
-const Footer = styled.div`
+
+const ModalText = styled(Text)`
+  margin-top: ${({ theme }) => theme.gaps.gap2};
+  line-height: 1.4;
+  word-break: keep-all;
+`;
+const ButtonGroup = styled.div`
   display: flex;
-  justify-content: space-between;
+  gap: 12px;
+  margin-top: ${({ theme }) => theme.gaps.gap4};
+`;
+
+const ModalButton = styled(Button)`
+  justify-content: center;
 `;


### PR DESCRIPTION
## 📝 작업한 내용

### Modal 컴포넌트 리팩토링
- 기존에 visible 속성으로 display 값을 제어해서 모달을 보여주던 것을 모달 자체를 추가 삭제 하는 방향으로 수정
- 모달이 떠있는 경우 뒤에 화면 스크롤되지 않도록 수정
- dim클릭시 닫히는 이벤트 선택 속성으로 수정

### ConfirmModal 컴포넌트 제작
- 현재 대부분 모달이 확인, 취소 형태로 사용중이기 때문에, 해당 모달을 편하게 사용할 수 있도록 ConfirmModal 제작

### 스토리북 제작
- 두 모달을 하나의 스토리북에 만들려고 했는데, 서로 받는 args가 달라서 일단 분리해서 제작해두었습니다! 혹시 한 파일에서 다르게 args를 넘기는 방법을 아신다면… 알려주세요ㅎㅎㅎ

## 📌 리뷰 시 참고 사항

- 이전에 논의했던 모달을 보여주는 방식을 숨기는 것이 아니라 추가, 삭제 하기로 하여 visible 속성을 제거하였습니다.
- 모달 컴포넌트 자체에 visible 속성이 없기 때문에 해당 모달을 사용하려면 외부에서 별도의 상태로 관리해야한다는 것을 인지하고 있어야 합니다.
- 모달을 숨김처리하지 않고 추가, 삭제를 하고 있어 모달이 생기고 사라질 때 애니메이션을 주기 어렵습니다(현재는 애니메이션이 없기 때문에 문제가 되지는 않습니다)
- 현재 사용중인 confirm 모달의 경우 dim을 클릭하여 모달을 닫지 못하게 하는 것이 사용자가 자신의 행동이 어떤 액션인지를 명확하게 인지할 수 있다고 생각됩니다. 그래서 atoms에 해당하는 모달은 dim 클릭 시 모달의 닫힘 여부를 선택할 수 있게 해두었고 confirm 모달의 경우는 dim을 클릭하여 모달을 닫지 못하게 하도록 설정해두었습니다.

## 📷 화면 사진
<img width="955" alt="스크린샷 2022-02-14 오후 6 26 06" src="https://user-images.githubusercontent.com/28250027/153837369-e6a3d558-ce1f-48e1-87aa-81db2d07fc71.png">

<img width="946" alt="스크린샷 2022-02-14 오후 6 25 57" src="https://user-images.githubusercontent.com/28250027/153837349-dd890b61-a2ee-42c6-b05d-fd64bccf3e34.png">


