### PR TITLE
[Film/#261] Icon 컴포넌트 타입 수정 및 반영

### DIFF
--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -3,4 +3,5 @@ export { ReactComponent as markerClose } from './icon_marker_close.svg';
 export { ReactComponent as markerCloseSelected } from './icon_marker_close_selected.svg';
 export { ReactComponent as markerOpen } from './icon_marker_open.svg';
 export { ReactComponent as markerOpenSelected } from './icon_marker_open_selected.svg';
-export { BiChevronLeft } from 'react-icons/bi';
+export { BiChevronLeft, BiLogOut, BiTrash, BiX, BiLeftArrowAlt } from 'react-icons/bi';
+export { MdHome, MdCollections, MdPerson, MdClose, MdErrorOutline } from 'react-icons/md';

--- a/src/components/atoms/Header/components/LeftSide/index.tsx
+++ b/src/components/atoms/Header/components/LeftSide/index.tsx
@@ -1,5 +1,5 @@
 import React, { MouseEvent } from 'react';
-import { BiChevronLeft } from 'react-icons/bi';
+import { Icon } from '@refactors/atoms';
 import { Wrapper } from './style';
 
 export interface Props {
@@ -10,7 +10,7 @@ export interface Props {
 const LeftSide = ({ leftComp, handleLeftEvent }: Props) => {
   return (
     <Wrapper onClick={handleLeftEvent}>
-      {leftComp && 'backBtn' && <BiChevronLeft size={24} />}
+      {leftComp && 'backBtn' && <Icon icon="BiChevronLeft" size={24} />}
     </Wrapper>
   );
 };

--- a/src/components/atoms/Header/components/RightSide/index.tsx
+++ b/src/components/atoms/Header/components/RightSide/index.tsx
@@ -1,5 +1,5 @@
 import React, { MouseEvent } from 'react';
-import { BiLogOut, BiTrash } from 'react-icons/bi';
+import { Icon } from '@refactors/atoms';
 import { Avatar, Text } from '../../..';
 import { Wrapper } from './style';
 import ProfileImg from '../../../../../assets/images/img_profile.svg';
@@ -14,8 +14,8 @@ const RightSide = ({ rightComp, handleRightEvent }: Props) => {
   return (
     <Wrapper onClick={handleRightEvent}>
       {rightComp === 'timeline' && <Text textType="Paragraph2">타임라인</Text>}
-      {rightComp === 'logout' && <BiLogOut size={24} />}
-      {rightComp === 'delete' && <BiTrash size={24} />}
+      {rightComp === 'logout' && <Icon icon="BiLogOut" size={24} />}
+      {rightComp === 'delete' && <Icon icon="BiTrash" size={24} />}
       {rightComp === 'mypage' && (
         <Avatar
           src={userInfo.profileImageUrl ? userInfo.profileImageUrl : ProfileImg}

--- a/src/components/organism/PreviewBottomSheet/index.tsx
+++ b/src/components/organism/PreviewBottomSheet/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { BiX } from 'react-icons/bi';
+import { Icon } from '@refactors/atoms';
 import { Avatar, Button, Text } from '../../atoms';
 import {
   BottomSheetWrapper,
@@ -69,7 +69,7 @@ const PreviewBottomSheet = ({ previewPost, postViewEvent, postDeleteEvent }: Pro
       )}
       <CloseBtn>
         <Link to="/">
-          <BiX size={24} />
+          <Icon icon="BiX" size={24} />
         </Link>
       </CloseBtn>
     </BottomSheetWrapper>

--- a/src/components/organism/SelectedUserList/SelectedUserCard.tsx/index.tsx
+++ b/src/components/organism/SelectedUserList/SelectedUserCard.tsx/index.tsx
@@ -1,4 +1,4 @@
-import { BiX } from 'react-icons/bi';
+import { Icon } from '@refactors/atoms';
 import { UserInfo } from '../../SearchUser';
 import { CardContainer, ContentWrapper, NicknameText, ProfileImg, RemoveBtn } from './style';
 import nonProfile from '../../../../assets/images/img_profile.svg';
@@ -17,7 +17,7 @@ const SelectedUserCard = ({ id, nickname, profileImageUrl, removeCard }: Props) 
   return (
     <CardContainer>
       <RemoveBtn onClick={handleRemoveClick}>
-        <BiX size={24}></BiX>
+        <Icon icon="BiX" size={24} />
       </RemoveBtn>
       <ContentWrapper>
         <ProfileImg

--- a/src/components/refactor/atoms/Icon/index.tsx
+++ b/src/components/refactor/atoms/Icon/index.tsx
@@ -6,8 +6,8 @@ const Icon = ({ icon, size = '1em', color, ...props }: IconProps) => {
   const SVGIcon = icons[icon];
 
   return (
-    <IconStyle color={color} size={size}>
-      <SVGIcon fill={color} size={size} {...props} />
+    <IconStyle size={size}>
+      <SVGIcon color={color} size={size} {...props} />
     </IconStyle>
   );
 };

--- a/src/components/refactor/atoms/Input/index.tsx
+++ b/src/components/refactor/atoms/Input/index.tsx
@@ -15,7 +15,7 @@ const Input = (
         invalid={invalid}
         {...props}
       ></StyledInput>
-      {invalid ? <AlertIcon size={24}></AlertIcon> : ''}
+      {invalid ? <AlertIcon icon="MdErrorOutline" size={24} color={'#F5544E'} /> : ''}
     </InputWrapper>
   );
 };

--- a/src/components/refactor/atoms/Input/style.ts
+++ b/src/components/refactor/atoms/Input/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
-import { MdErrorOutline } from 'react-icons/md';
 import { InputProps } from './types';
 import calenderIcon from '../../../../assets/icons/icon_calender.svg';
+import { Icon } from '@refactors/atoms';
 
 const StyledInput = styled.input<InputProps>`
   ${({ theme }) => theme.fonts.Paragraph1};
@@ -49,8 +49,7 @@ const InputWrapper = styled.div`
   display: flex;
   position: relative;
 `;
-const AlertIcon = styled(MdErrorOutline)`
-  color: ${({ theme }) => theme.colors.red900};
+const AlertIcon = styled(Icon)`
   position: absolute;
   right: 24px;
   top: 25%;

--- a/src/components/refactor/atoms/Toast/components/ToastItem/index.tsx
+++ b/src/components/refactor/atoms/Toast/components/ToastItem/index.tsx
@@ -19,7 +19,7 @@ const ToastItem = ({ type, msg1, msg2, duration, onDone }: Props) => {
     >
       <ProgressBar style={{ animationDuration: `${duration}ms` }} />
       <Body>
-        <CloseBtn onClick={onDone} />
+        <CloseBtn icon="MdClose" size="1rem" color="white" onClick={onDone} />
         <Content>{msg1}</Content>
         {msg2 && <Content>{msg2}</Content>}
       </Body>

--- a/src/components/refactor/atoms/Toast/components/ToastItem/style.ts
+++ b/src/components/refactor/atoms/Toast/components/ToastItem/style.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { MdClose } from 'react-icons/md';
+import { Icon } from '@refactors/atoms';
 
 const Container = styled.div`
   position: relative;
@@ -59,9 +59,7 @@ const ProgressBar = styled.div`
   }
 `;
 
-const CloseBtn = styled(MdClose)`
-  color: white;
-  size: 1rem;
+const CloseBtn = styled(Icon)`
   position: absolute;
   right: 20px;
 `;

--- a/src/components/refactor/atoms/index.ts
+++ b/src/components/refactor/atoms/index.ts
@@ -1,7 +1,7 @@
+export { default as Icon } from './Icon';
 export { default as Text } from './Text';
 export { default as Button } from './Button';
 export { default as Input } from './Input';
 export { default as Img } from './Img';
-export { default as Icon } from './Icon';
 export { default as LottieLoader } from './LottieLoader';
 export { default as Modal } from './Modal';


### PR DESCRIPTION
## 📝 작업한 내용
- 사용중인 react-icon을 Icon 타입으로 지정
- react-icon을 중심으로 컬러 속성 받을 수 있도록 수정
 
## 📌 리뷰 시 참고 사항
- 자체 제작한 아이콘은 컬러가 보통 정해져있는 경우가 많기 때문에, Icon 컴포넌트의 컬러 속성은 react-icon을 우선하여 적용하도록 하였습니다.

